### PR TITLE
Stack allocator enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The following compiler options can be set when building your application:
 * `__QUANTUM_PRINT_DEBUG`         : Prints debug and error information to `stdout` and `stderr` respectively.
 * `__QUANTUM_YIELD_WITHOUT_SLEEP` : Yields a coroutine thread instead of sleeping it when blocked. This could result in performance improvement in some cases.
 * `__QUANTUM_DEFAULT_STACK_ALLOC_SIZE=<NUM>` : Change the size of the stack allocation buffers for internal objects. Default is 1000.
+* `__QUANTUM_USE_DEFAULT_ALLOCATOR` : Disable internal stack allocation and use default system allocators instead.
 
 ### Documentation
 Please see the [wiki](https://github.com/bloomberg/quantum/wiki) page for a detailed overview of this library, use-case scenarios and examples.

--- a/src/quantum/impl/quantum_io_queue_impl.h
+++ b/src/quantum/impl/quantum_io_queue_impl.h
@@ -25,6 +25,7 @@ namespace quantum {
 inline
 IoQueue::IoQueue(IoQueue* mainIoQueue) :
     _sharedIoQueue(mainIoQueue),
+    _queue(GetQueueListAllocator()),
     _isEmpty(true),
     _isInterrupted(false),
     _isIdle(true),

--- a/src/quantum/impl/quantum_shared_state_impl.h
+++ b/src/quantum/impl/quantum_shared_state_impl.h
@@ -213,7 +213,7 @@ int SharedState<T>::setException(std::exception_ptr ex)
         _exception = ex;
     }
     _cond.notifyAll();
-    return 0;
+    return -1;
 }
 
 template <class T>
@@ -225,7 +225,7 @@ int SharedState<T>::setException(ICoroSync::Ptr sync,
         _exception = ex;
     }
     _cond.notifyAll();
-    return 0;
+    return -1;
 }
 
 template <class T>

--- a/src/quantum/impl/quantum_stack_traits_impl.h
+++ b/src/quantum/impl/quantum_stack_traits_impl.h
@@ -1,0 +1,56 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+//NOTE: DO NOT INCLUDE DIRECTLY
+
+//##############################################################################################
+//#################################### IMPLEMENTATIONS #########################################
+//##############################################################################################
+
+namespace Bloomberg {
+namespace quantum {
+
+bool& StackTraits::isUnbounded()
+{
+    static bool isUnbounded = boost::context::stack_traits::is_unbounded();
+    return isUnbounded;
+}
+    
+size_t& StackTraits::pageSize()
+{
+    static size_t pageSize = boost::context::stack_traits::page_size();
+    return pageSize;
+}
+
+size_t& StackTraits::defaultSize()
+{
+    static size_t defaultSize = boost::context::stack_traits::default_size();
+    return defaultSize;
+}
+    
+
+size_t& StackTraits::minimumSize()
+{
+    static size_t minimumSize = boost::context::stack_traits::minimum_size();
+    return minimumSize;
+}
+
+size_t& StackTraits::maximumSize()
+{
+    static size_t maximumSize = boost::context::stack_traits::maximum_size();
+    return maximumSize;
+}
+
+}}

--- a/src/quantum/impl/quantum_task_queue_impl.h
+++ b/src/quantum/impl/quantum_task_queue_impl.h
@@ -24,6 +24,7 @@ namespace quantum {
 
 inline
 TaskQueue::TaskQueue() :
+    _queue(GetQueueListAllocator()),
     _queueIt(_queue.end()),
     _isEmpty(true),
     _isInterrupted(false),
@@ -100,7 +101,7 @@ void TaskQueue::run()
                     //Coroutine ended normally with "return 0" statement
                     _stats.incCompletedCount();
                     
-                    //check to see interfaces there's another task scheduled to run after this one
+                    //check if there's another task scheduled to run after this one
                     nextTask = task->getNextTask();
                     if (nextTask && (nextTask->getType() == ITask::Type::ErrorHandler))
                     {
@@ -125,7 +126,7 @@ void TaskQueue::run()
                         std::cerr << "Coroutine exited with error : " << rc << std::endl;
                     }
 #endif
-                    //Check to see interfaces we have a final task to run
+                    //Check if we have a final task to run
                     nextTask = task->getErrorHandlerOrFinalTask();
                 }
                 

--- a/src/quantum/interface/quantum_iqueue.h
+++ b/src/quantum/interface/quantum_iqueue.h
@@ -20,6 +20,7 @@
 #include <quantum/interface/quantum_iterminate.h>
 #include <quantum/interface/quantum_itask.h>
 #include <quantum/interface/quantum_iqueue_statistics.h>
+#include <quantum/quantum_stack_allocator.h>
 
 namespace Bloomberg {
 namespace quantum {
@@ -57,6 +58,20 @@ struct IQueue : public ITerminate
     
     virtual bool isIdle() const = 0;
 };
+
+#ifndef __QUANTUM_QUEUE_LIST_ALLOC
+    #define __QUANTUM_QUEUE_LIST_ALLOC __QUANTUM_DEFAULT_STACK_ALLOC_SIZE
+#endif
+#ifndef __QUANTUM_USE_DEFAULT_ALLOCATOR
+    using QueueListAllocator = StackAllocator<ITask::Ptr, __QUANTUM_QUEUE_LIST_ALLOC>;
+#else
+    using QueueListAllocator = std::allocator<ITask::Ptr>;
+#endif
+
+inline QueueListAllocator&  GetQueueListAllocator() {
+    static QueueListAllocator allocator;
+    return allocator;
+}
 
 }}
 

--- a/src/quantum/quantum.h
+++ b/src/quantum/quantum.h
@@ -53,6 +53,7 @@
 #include <quantum/quantum_shared_state.h>
 #include <quantum/quantum_spinlock.h>
 #include <quantum/quantum_stack_allocator.h>
+#include <quantum/quantum_stack_traits.h>
 #include <quantum/quantum_task.h>
 #include <quantum/quantum_task_queue.h>
 #include <quantum/quantum_traits.h>

--- a/src/quantum/quantum_io_queue.h
+++ b/src/quantum/quantum_io_queue.h
@@ -39,7 +39,7 @@ namespace quantum {
 class IoQueue : public IQueue
 {
 public:
-    using TaskList = std::list<IoTask::Ptr>;
+    using TaskList = std::list<IoTask::Ptr, QueueListAllocator>;
     using TaskListIter = TaskList::iterator;
     
     explicit IoQueue(IoQueue* mainIoQueue = nullptr);

--- a/src/quantum/quantum_stack_allocator.h
+++ b/src/quantum/quantum_stack_allocator.h
@@ -29,7 +29,9 @@ namespace quantum {
 //==============================================================================
 //                               Helpers
 //==============================================================================
+#ifndef __QUANTUM_DEFAULT_STACK_ALLOC_SIZE
 #define __QUANTUM_DEFAULT_STACK_ALLOC_SIZE 1000
+#endif
 
 template <int N> //N == 0
 struct index {

--- a/src/quantum/quantum_stack_traits.h
+++ b/src/quantum/quantum_stack_traits.h
@@ -1,0 +1,61 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef QUANTUM_STACK_TRAITS_H
+#define QUANTUM_STACK_TRAITS_H
+
+#include <boost/context/stack_traits.hpp>
+
+namespace Bloomberg {
+namespace quantum {
+
+//==============================================================================================
+//                                 class StackTraits
+//==============================================================================================
+/// @struct StackParameters.
+/// @brief Allows overrides for the coroutine stack traits which is used internally by the coroutine allocators.
+/// @note See boost::context::stack_traits for details. Typically only the default size should be modified.
+
+class StackTraits {
+public:
+    /// @brief Get/set if the environment defines a limit for the stack size.
+    /// @return Modifiable reference.
+    static bool& isUnbounded();
+    
+    /// @brief Get/set the page size.
+    /// @return Modifiable reference to the size in bytes.
+    static size_t& pageSize();
+    
+    /// @brief Get/set the default stack size, which may be platform specific.
+    /// @return Modifiable reference to the size in bytes.
+    /// @detail If the stack is unbounded, the default boost implementation returns the max of {64kB, minimum_size()}.
+    static size_t& defaultSize();
+    
+    /// @brief Get/set the minimum stack size as defined by the environment.
+    /// @return Modifiable reference to the size in bytes.
+    /// @note Win32 4kB/Win64 8kB, defined by rlimit on POSIX.
+    static size_t& minimumSize();
+    
+    /// @brief Get/set the maximum stack size.
+    /// @return Modifiable reference to the size in bytes.
+    /// @note Only takes effect if isUnbounded() == false.
+    static size_t& maximumSize();
+};
+
+}}
+
+#include <quantum/impl/quantum_stack_traits_impl.h>
+
+#endif //QUANTUM_STACK_TRAITS_H

--- a/src/quantum/quantum_task_queue.h
+++ b/src/quantum/quantum_task_queue.h
@@ -44,7 +44,7 @@ namespace quantum {
 class TaskQueue : public IQueue
 {
 public:
-    using TaskList = std::list<Task::Ptr>;
+    using TaskList = std::list<Task::Ptr, QueueListAllocator>;
     using TaskListIter = TaskList::iterator;
     
     TaskQueue();

--- a/src/quantum/quantum_traits.h
+++ b/src/quantum/quantum_traits.h
@@ -16,7 +16,11 @@
 #ifndef QUANTUM_TRAITS_H
 #define QUANTUM_TRAITS_H
 
+#include <quantum/quantum_stack_traits.h>
 #include <boost/coroutine2/all.hpp>
+#include <boost/context/stack_traits.hpp>
+#include <boost/coroutine2/pooled_fixedsize_stack.hpp>
+#include <boost/coroutine2/fixedsize_stack.hpp>
 #include <iterator>
 #include <type_traits>
 
@@ -35,6 +39,18 @@ class Buffer; //fwd declaration
 /// @brief Contains definitions for various traits used by this library. For internal use only.
 struct Traits
 {
+    struct StackTraitsProxy {
+        static bool is_unbounded() { return StackTraits::isUnbounded(); }
+        static std::size_t page_size() { return StackTraits::pageSize(); }
+        static std::size_t default_size() { return StackTraits::defaultSize(); }
+        static std::size_t minimum_size() { return StackTraits::minimumSize(); }
+        static std::size_t maximum_size() { return StackTraits::maximumSize(); }
+    };
+//#ifndef __QUANTUM_USE_DEFAULT_ALLOCATOR
+//    using CoroStackAllocator = boost::context::basic_pooled_fixedsize_stack<StackTraitsProxy>;
+//#else
+    using CoroStackAllocator = boost::context::basic_fixedsize_stack<StackTraitsProxy>;
+//#endif
     using BoostCoro = boost::coroutines2::coroutine<int&>;
     using Yield     = typename BoostCoro::pull_type;
     using Coroutine = typename BoostCoro::push_type;

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -644,9 +644,8 @@ TEST(PromiseTest, SetExceptionInPromise)
         }
         catch (...)
         {
-            ctx->setException(std::current_exception());
+            return ctx->setException(std::current_exception());
         }
-        return 0;
     });
     EXPECT_THROW(ctx->get(), int);
 }


### PR DESCRIPTION
- Added allocators for task lists
- Static assert for the number of allocated blocks
- Added overrides for coroutine stack traits via new `StackTraits` class.
- Provided default boost allocator for coroutine stacks.
- Ability to completely turn off stack allocations via __QUANTUM_USE_DEFAULT_ALLOCATOR macro
- Fixed `SharedState::setException` to return -1 instead of 0 so the dispatcher properly treats it as an error.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>