### PR TITLE
Refactored allocator logic to allow modification at runtime via stati…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ add_definitions(
         -D_THREAD_SAFE
         -D_POSIX_PTHREAD_SEMANTICS
         -D__FUNCTION__=__FILE__
+        #-D__QUANTUM_DEFAULT_POOL_ALLOC_SIZE=1000
+        #-D__QUANTUM_DEFAULT_CORO_POOL_ALLOC_SIZE=200
+        #-D__QUANTUM_USE_DEFAULT_ALLOCATOR
+        #-D__QUANTUM_USE_DEFAULT_CORO_ALLOCATOR
+        #-D__QUANTUM_ALLOCATE_POOL_FROM_HEAP
 )
 add_compile_options(-Wall -Wextra -Werror -Wabi -O0 -m${MODE} -std=gnu++${CMAKE_CXX_STANDARD} -ftemplate-backtrace-limit=0)
 

--- a/src/quantum/impl/quantum_context_impl.h
+++ b/src/quantum/impl/quantum_context_impl.h
@@ -18,8 +18,7 @@
 //##############################################################################################
 //#################################### IMPLEMENTATIONS #########################################
 //##############################################################################################
-#include <quantum/quantum_stack_allocator.h>
-#include <quantum/quantum_heap_allocator.h>
+#include <quantum/quantum_allocator.h>
 
 namespace Bloomberg {
 namespace quantum {
@@ -269,23 +268,18 @@ ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, AR
 //==============================================================================================
 //                                     class Context
 //==============================================================================================
-#ifndef __QUANTUM_CONTEXT_ALLOC
-    #define __QUANTUM_CONTEXT_ALLOC __QUANTUM_DEFAULT_POOL_ALLOC_SIZE
+#ifndef __QUANTUM_CONTEXT_ALLOC_SIZE
+    #define __QUANTUM_CONTEXT_ALLOC_SIZE __QUANTUM_DEFAULT_POOL_ALLOC_SIZE
 #endif
 #ifndef __QUANTUM_USE_DEFAULT_ALLOCATOR
     #ifdef __QUANTUM_ALLOCATE_POOL_FROM_HEAP
-        using ContextAllocator = HeapAllocator<Context<int>, __QUANTUM_CONTEXT_ALLOC>;
+        using ContextAllocator = HeapAllocator<Context<int>>;
     #else
-        using ContextAllocator = StackAllocator<Context<int>, __QUANTUM_CONTEXT_ALLOC>;
+        using ContextAllocator = StackAllocator<Context<int>, __QUANTUM_CONTEXT_ALLOC_SIZE>;
     #endif
 #else
-    using ContextAllocator = std::allocator<Context<int>>;
+    using ContextAllocator = StlAllocator<Context<int>>;
 #endif
-
-inline ContextAllocator&  GetContextAllocator() {
-    static ContextAllocator allocator;
-    return allocator;
-}
 
 template <class RET>
 Context<RET>::Context(DispatcherCore& dispatcher) :
@@ -848,20 +842,20 @@ Context<RET>::postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&
 template <class RET>
 void* Context<RET>::operator new(size_t size)
 {
-    return GetContextAllocator().allocate(size);
+    return Allocator<ContextAllocator>::instance(AllocatorTraits::contextAllocSize()).allocate(size);
 }
 
 template <class RET>
 void Context<RET>::operator delete(void* p)
 {
-    GetContextAllocator().deallocate(static_cast<Context<int>*>(p), 1);
+    Allocator<ContextAllocator>::instance(AllocatorTraits::contextAllocSize()).deallocate(static_cast<Context<int>*>(p), 1);
 }
 
 template <class RET>
 void Context<RET>::deleter(Context<RET>* p)
 {
 #ifndef __QUANTUM_USE_DEFAULT_ALLOCATOR
-    GetContextAllocator().dispose(reinterpret_cast<Context<int>*>(p));
+    Allocator<ContextAllocator>::instance(AllocatorTraits::contextAllocSize()).dispose(reinterpret_cast<Context<int>*>(p));
 #else
     delete p;
 #endif

--- a/src/quantum/impl/quantum_contiguous_pool_manager_impl.h
+++ b/src/quantum/impl/quantum_contiguous_pool_manager_impl.h
@@ -15,6 +15,8 @@
 */
 //NOTE: DO NOT INCLUDE DIRECTLY
 #include <type_traits>
+#include <assert.h>
+#include <exception>
 
 //##############################################################################################
 //#################################### IMPLEMENTATIONS #########################################
@@ -22,95 +24,95 @@
 namespace Bloomberg {
 namespace quantum {
 
-template <typename T, unsigned int SIZE>
-ContiguousPoolManager<T,SIZE>::ContiguousPoolManager() :
-    _buffer(nullptr)
+template <typename T>
+ContiguousPoolManager<T>::ContiguousPoolManager()
 {
-    static_assert(SIZE > 0, "Allocator buffer size must be > 0");
-    //build the free stack
-    for (size_t i = 0; i < SIZE; ++i) {
-        _freeBlocks[i] = i;
-    }
 }
 
-template <typename T, unsigned int SIZE>
-ContiguousPoolManager<T,SIZE>::ContiguousPoolManager(aligned_type* buffer) :
-    _buffer(buffer)
+template <typename T>
+ContiguousPoolManager<T>::ContiguousPoolManager(aligned_type* buffer, size_type size)
 {
-    if (!_buffer) {
-        throw std::runtime_error("Null buffer");
-    }
-    //build the free stack
-    for (size_t i = 0; i < SIZE; ++i) {
-        _freeBlocks[i] = i;
-    }
+    setBuffer(buffer, size);
 }
 
-template <typename T, unsigned int SIZE>
-ContiguousPoolManager<T,SIZE>::ContiguousPoolManager(ContiguousPoolManager<T,SIZE>&& other) :
-    _buffer(other.buffer),
-    _freeBlockIndex(other._freeBlockIndex),
-    _numHeapAllocatedBlocks(other._numHeapAllocatedBlocks),
-    _spinlock(std::move(other._spinlock))
+template <typename T>
+ContiguousPoolManager<T>::ContiguousPoolManager(ContiguousPoolManager<T>&& other)
 {
-    // Reset other
-    std::copy(std::begin(_freeBlocks), std::end(_freeBlocks), std::begin(other._freeBlocks));
-    other._buffer = nullptr;
-    other._freeBlockIndex = -1;
-    other._numHeapAllocatedBlocks = 0;
+    *this = std::move(other);
 }
 
-template <typename T, unsigned int SIZE>
-ContiguousPoolManager<T,SIZE>& ContiguousPoolManager<T,SIZE>::operator=(ContiguousPoolManager<T,SIZE>&& other)
+template <typename T>
+ContiguousPoolManager<T>& ContiguousPoolManager<T>::operator=(ContiguousPoolManager<T>&& other)
 {
-    _buffer(other.buffer),
-    std::copy(std::begin(_freeBlocks), std::end(_freeBlocks), std::begin(other._freeBlocks));
+    _size = other._size;
+    _buffer = other.buffer;
+    _freeBlocks = other._freeBlocks;
     _freeBlockIndex = other._freeBlockIndex;
     _numHeapAllocatedBlocks = other._numHeapAllocatedBlocks;
     _spinlock = std::move(other._spinlock);
     
     // Reset other
     other._buffer = nullptr;
+    other._freeBlocks = nullptr;
     other._freeBlockIndex = -1;
     other._numHeapAllocatedBlocks = 0;
 }
 
-template <typename T, unsigned int SIZE>
-void ContiguousPoolManager<T,SIZE>::setBuffer(aligned_type *buffer)
+template <typename T>
+ContiguousPoolManager<T>::~ContiguousPoolManager()
+{
+    delete[] _freeBlocks;
+}
+
+template <typename T>
+void ContiguousPoolManager<T>::setBuffer(aligned_type *buffer, size_type size)
 {
     if (!buffer) {
         throw std::runtime_error("Null buffer");
     }
+    if (size == 0) {
+        throw std::runtime_error("Invalid allocator pool size");
+    }
+    _size = size;
     _buffer = buffer;
+    _freeBlocks = new size_type[size];
+    if (!_freeBlocks) {
+        throw std::bad_alloc();
+    }
+    _freeBlockIndex = size-1;
+    //build the free stack
+    for (size_type i = 0; i < size; ++i) {
+        _freeBlocks[i] = i;
+    }
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::pointer ContiguousPoolManager<T,SIZE>::address(reference x) const
+template <typename T>
+typename ContiguousPoolManager<T>::pointer ContiguousPoolManager<T>::address(reference x) const
 {
     return &x;
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::const_pointer ContiguousPoolManager<T,SIZE>::address(const_reference x) const
+template <typename T>
+typename ContiguousPoolManager<T>::const_pointer ContiguousPoolManager<T>::address(const_reference x) const
 {
     return &x;
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::size_type ContiguousPoolManager<T,SIZE>::max_size() const
+template <typename T>
+typename ContiguousPoolManager<T>::size_type ContiguousPoolManager<T>::max_size() const
 {
     return 1; //only 1 supported for now
 }
 
-template <typename T, unsigned int SIZE>
+template <typename T>
 template <typename... Args >
-void ContiguousPoolManager<T,SIZE>::construct(T* p, Args&&... args)
+void ContiguousPoolManager<T>::construct(T* p, Args&&... args)
 {
     new((void *)p) T(std::forward<Args>(args)...); // construct in-place
 }
 
-template <typename T, unsigned int SIZE>
-void ContiguousPoolManager<T,SIZE>::destroy(pointer p)
+template <typename T>
+void ContiguousPoolManager<T>::destroy(pointer p)
 {
     if (p != nullptr)
     {
@@ -118,9 +120,9 @@ void ContiguousPoolManager<T,SIZE>::destroy(pointer p)
     }
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::pointer ContiguousPoolManager<T,SIZE>::allocate(size_type,
-                                                                    std::allocator<void>::const_pointer)
+template <typename T>
+typename ContiguousPoolManager<T>::pointer
+ContiguousPoolManager<T>::allocate(size_type, const_pointer)
 {
     assert(_buffer);
     {
@@ -135,8 +137,8 @@ typename ContiguousPoolManager<T,SIZE>::pointer ContiguousPoolManager<T,SIZE>::a
     return (pointer)new char[sizeof(value_type)];
 }
 
-template <typename T, unsigned int SIZE>
-void ContiguousPoolManager<T,SIZE>::deallocate(pointer p, size_type)
+template <typename T>
+void ContiguousPoolManager<T>::deallocate(pointer p, size_type)
 {
     assert(_buffer);
     if (p == nullptr) {
@@ -155,68 +157,68 @@ void ContiguousPoolManager<T,SIZE>::deallocate(pointer p, size_type)
     }
 }
 
-template <typename T, unsigned int SIZE>
+template <typename T>
 template <typename... Args >
-typename ContiguousPoolManager<T,SIZE>::pointer ContiguousPoolManager<T,SIZE>::create(Args&&... args)
+typename ContiguousPoolManager<T>::pointer ContiguousPoolManager<T>::create(Args&&... args)
 {
     T* p = allocate();
     construct(p, std::forward<Args>(args)...);
     return p;
 }
 
-template <typename T, unsigned int SIZE>
-void ContiguousPoolManager<T,SIZE>::dispose(pointer p)
+template <typename T>
+void ContiguousPoolManager<T>::dispose(pointer p)
 {
     destroy(p);
     deallocate(p);
 }
 
-template <typename T, unsigned int SIZE>
-size_t ContiguousPoolManager<T,SIZE>::allocatedBlocks() const
+template <typename T>
+size_t ContiguousPoolManager<T>::allocatedBlocks() const
 {
-    return SIZE - _freeBlockIndex - 1;
+    return _size ? _size - _freeBlockIndex - 1 : 0;
 }
 
-template <typename T, unsigned int SIZE>
-size_t ContiguousPoolManager<T,SIZE>::allocatedHeapBlocks() const
+template <typename T>
+size_t ContiguousPoolManager<T>::allocatedHeapBlocks() const
 {
     return _numHeapAllocatedBlocks;
 }
 
-template <typename T, unsigned int SIZE>
-bool ContiguousPoolManager<T,SIZE>::isFull() const
+template <typename T>
+bool ContiguousPoolManager<T>::isFull() const
 {
-    return _freeBlockIndex == SIZE-1;
+    return _freeBlockIndex == _size-1;
 }
 
-template <typename T, unsigned int SIZE>
-bool ContiguousPoolManager<T,SIZE>::isEmpty() const
+template <typename T>
+bool ContiguousPoolManager<T>::isEmpty() const
 {
     return _freeBlockIndex == -1;
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::pointer ContiguousPoolManager<T,SIZE>::bufferStart()
+template <typename T>
+typename ContiguousPoolManager<T>::pointer ContiguousPoolManager<T>::bufferStart()
 {
     return reinterpret_cast<pointer>(_buffer);
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::pointer ContiguousPoolManager<T,SIZE>::bufferEnd()
+template <typename T>
+typename ContiguousPoolManager<T>::pointer ContiguousPoolManager<T>::bufferEnd()
 {
-    return reinterpret_cast<pointer>(_buffer + SIZE);
+    return reinterpret_cast<pointer>(_buffer + _size);
 }
 
-template <typename T, unsigned int SIZE>
-bool ContiguousPoolManager<T,SIZE>::isManaged(pointer p)
+template <typename T>
+bool ContiguousPoolManager<T>::isManaged(pointer p)
 {
     return (bufferStart() <= p) && (p < bufferEnd());
 }
 
-template <typename T, unsigned int SIZE>
-typename ContiguousPoolManager<T,SIZE>::index_type ContiguousPoolManager<T,SIZE>::blockIndex(pointer p)
+template <typename T>
+typename ContiguousPoolManager<T>::size_type ContiguousPoolManager<T>::blockIndex(pointer p)
 {
-    return reinterpret_cast<aligned_type*>(p) - _buffer;
+    return static_cast<size_type>(reinterpret_cast<aligned_type*>(p) - _buffer);
 }
 
 }}

--- a/src/quantum/impl/quantum_io_queue_impl.h
+++ b/src/quantum/impl/quantum_io_queue_impl.h
@@ -25,7 +25,7 @@ namespace quantum {
 inline
 IoQueue::IoQueue(IoQueue* mainIoQueue) :
     _sharedIoQueue(mainIoQueue),
-    _queue(GetQueueListAllocator()),
+    _queue(Allocator<QueueListAllocator>::instance(AllocatorTraits::queueListAllocSize())),
     _isEmpty(true),
     _isInterrupted(false),
     _isIdle(true),

--- a/src/quantum/impl/quantum_stl_impl.h
+++ b/src/quantum/impl/quantum_stl_impl.h
@@ -16,11 +16,8 @@
 #ifndef QUANTUM_STL_IMPL_H
 #define QUANTUM_STL_IMPL_H
 
-#include <quantum/quantum_traits.h>
 #include <tuple>
 #include <utility>
-
-using Traits = Bloomberg::quantum::Traits;
 
 namespace std {
 #if (__cplusplus == 201103L)

--- a/src/quantum/impl/quantum_task_queue_impl.h
+++ b/src/quantum/impl/quantum_task_queue_impl.h
@@ -24,7 +24,7 @@ namespace quantum {
 
 inline
 TaskQueue::TaskQueue() :
-    _queue(GetQueueListAllocator()),
+    _queue(Allocator<QueueListAllocator>::instance(AllocatorTraits::queueListAllocSize())),
     _queueIt(_queue.end()),
     _isEmpty(true),
     _isInterrupted(false),

--- a/src/quantum/interface/quantum_iqueue.h
+++ b/src/quantum/interface/quantum_iqueue.h
@@ -20,8 +20,7 @@
 #include <quantum/interface/quantum_iterminate.h>
 #include <quantum/interface/quantum_itask.h>
 #include <quantum/interface/quantum_iqueue_statistics.h>
-#include <quantum/quantum_stack_allocator.h>
-#include <quantum/quantum_heap_allocator.h>
+#include <quantum/quantum_allocator.h>
 
 namespace Bloomberg {
 namespace quantum {
@@ -60,23 +59,18 @@ struct IQueue : public ITerminate
     virtual bool isIdle() const = 0;
 };
 
-#ifndef __QUANTUM_QUEUE_LIST_ALLOC
-    #define __QUANTUM_QUEUE_LIST_ALLOC __QUANTUM_DEFAULT_POOL_ALLOC_SIZE
+#ifndef __QUANTUM_QUEUE_LIST_ALLOC_SIZE
+    #define __QUANTUM_QUEUE_LIST_ALLOC_SIZE __QUANTUM_DEFAULT_POOL_ALLOC_SIZE
 #endif
 #ifndef __QUANTUM_USE_DEFAULT_ALLOCATOR
     #ifdef __QUANTUM_ALLOCATE_POOL_FROM_HEAP
-        using QueueListAllocator = HeapAllocator<ITask::Ptr, __QUANTUM_QUEUE_LIST_ALLOC>;
+        using QueueListAllocator = HeapAllocator<ITask::Ptr>;
     #else
-        using QueueListAllocator = StackAllocator<ITask::Ptr, __QUANTUM_QUEUE_LIST_ALLOC>;
+        using QueueListAllocator = StackAllocator<ITask::Ptr, __QUANTUM_QUEUE_LIST_ALLOC_SIZE>;
     #endif
 #else
-    using QueueListAllocator = std::allocator<ITask::Ptr>;
+    using QueueListAllocator = StlAllocator<ITask::Ptr>;
 #endif
-
-inline QueueListAllocator&  GetQueueListAllocator() {
-    static QueueListAllocator allocator;
-    return allocator;
-}
 
 }}
 

--- a/src/quantum/quantum.h
+++ b/src/quantum/quantum.h
@@ -39,6 +39,8 @@
 #include <quantum/interface/quantum_ithread_future.h>
 #include <quantum/interface/quantum_ithread_future_base.h>
 #include <quantum/interface/quantum_ithread_promise.h>
+#include <quantum/quantum_allocator.h>
+#include <quantum/quantum_allocator_traits.h>
 #include <quantum/quantum_buffer.h>
 #include <quantum/quantum_condition_variable.h>
 #include <quantum/quantum_context.h>

--- a/src/quantum/quantum_allocator.h
+++ b/src/quantum/quantum_allocator.h
@@ -1,0 +1,70 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef QUANTUM_ALLOCATOR_H
+#define QUANTUM_ALLOCATOR_H
+
+#include <quantum/impl/quantum_stl_impl.h>
+#include <quantum/quantum_allocator_traits.h>
+#include <quantum/quantum_stack_allocator.h>
+#include <quantum/quantum_heap_allocator.h>
+#include <quantum/quantum_coroutine_pool_allocator.h>
+#include <boost/context/stack_traits.hpp>
+#include <boost/coroutine2/pooled_fixedsize_stack.hpp>
+#include <boost/coroutine2/fixedsize_stack.hpp>
+#include <memory>
+
+namespace Bloomberg {
+namespace quantum {
+
+//==============================================================================================
+//                                 struct StlAllocator
+//==============================================================================================
+template <typename T>
+struct StlAllocator : public std::allocator<T>
+{
+    typedef std::true_type default_constructor;
+};
+
+//==============================================================================================
+//                                 struct BoostAllocator
+//==============================================================================================
+template <typename Traits>
+struct BoostAllocator : public boost::context::basic_fixedsize_stack<Traits>
+{
+    typedef std::true_type default_constructor;
+};
+
+//==============================================================================================
+//                               struct Allocator (singleton)
+//==============================================================================================
+template <typename AllocType>
+struct Allocator {
+    template <typename A = AllocType>
+    static AllocType& instance(std::enable_if_t<!A::default_constructor::value, uint16_t> size) {
+       static AllocType allocator(size);
+       return allocator;
+    }
+    template <typename A = AllocType>
+    static AllocType& instance(std::enable_if_t<A::default_constructor::value, uint16_t> = 0) {
+       static AllocType allocator;
+       return allocator;
+    }
+};
+
+}
+}
+
+#endif //QUANTUM_ALLOCATOR_H

--- a/src/quantum/quantum_allocator_traits.h
+++ b/src/quantum/quantum_allocator_traits.h
@@ -1,0 +1,166 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef QUANTUM_ALLOCATOR_TRAITS_H
+#define QUANTUM_ALLOCATOR_TRAITS_H
+
+#include <cstdint>
+
+namespace Bloomberg {
+namespace quantum {
+
+#ifndef __QUANTUM_DEFAULT_POOL_ALLOC_SIZE
+    #ifdef __QUANTUM_DEFAULT_STACK_ALLOC_SIZE
+        #warning Deprecated : use __QUANTUM_DEFAULT_POOL_ALLOC_SIZE instead.
+        #define __QUANTUM_DEFAULT_POOL_ALLOC_SIZE __QUANTUM_DEFAULT_STACK_ALLOC_SIZE
+    #else
+        #define __QUANTUM_DEFAULT_POOL_ALLOC_SIZE 1000
+    #endif
+#endif
+
+#ifndef __QUANTUM_DEFAULT_CORO_POOL_ALLOC_SIZE
+    #define __QUANTUM_DEFAULT_CORO_POOL_ALLOC_SIZE 200
+#endif
+
+//==============================================================================================
+//                                 struct AllocatorTraits
+//==============================================================================================
+struct AllocatorTraits {
+    using size_type = uint16_t;
+    
+    /**
+     * @brief Get/set if the system allocator should be used for internal objects (other than coroutine stacks).
+     * @return A modifiable reference to the value.
+     * @remark For future use.
+     */
+    static bool& useDefaultAllocator() {
+#ifdef __QUANTUM_USE_DEFAULT_ALLOCATOR
+        static bool value = true;
+#else
+        static bool value = false;
+#endif
+        return value;
+    }
+    
+    /**
+     * @brief Get/set if the system allocator should be used for coroutine stacks.
+     * @return A modifiable reference to the value.
+     * @remark For future use.
+     */
+    static bool& useDefaultCoroAllocator() {
+#ifdef __QUANTUM_USE_DEFAULT_CORO_ALLOCATOR
+        static bool value = true;
+#else
+        static bool value = false;
+#endif
+        return value;
+    }
+    
+    /**
+     * @brief Get/set if the allocator pool for internal objects should use the heap or the application stack.
+     * @return A modifiable reference to the value.
+     * @remark For future use. If set to 'false', object pools will be allocated on the stack.
+     */
+    static bool& allocatePoolFromHeap() {
+#ifdef __QUANTUM_ALLOCATE_POOL_FROM_HEAP
+        static bool value = true;
+#else
+        static bool value = false;
+#endif
+        return value;
+    }
+    
+    /**
+     * @brief Get/set if the default size for internal object pools (other than coroutine stacks).
+     * @return A modifiable reference to the value.
+     */
+    static size_type& defaultPoolAllocSize() {
+        static size_type size = __QUANTUM_DEFAULT_POOL_ALLOC_SIZE;
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for coroutine stack pools.
+     * @return A modifiable reference to the value.
+     */
+    static size_type& defaultCoroPoolAllocSize() {
+        static size_type size = __QUANTUM_DEFAULT_CORO_POOL_ALLOC_SIZE;
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for promise object pools.
+     * @return A modifiable reference to the value.
+     * @remark Normally this should not be modified unless very specific tuning is needed.
+     */
+    static size_type& promiseAllocSize() {
+        static size_type size = defaultPoolAllocSize();
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for future object pools.
+     * @return A modifiable reference to the value.
+     * @remark Normally this should not be modified unless very specific tuning is needed.
+     */
+    static size_type& futureAllocSize() {
+        static size_type size = defaultPoolAllocSize();
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for context object pools.
+     * @return A modifiable reference to the value.
+     * @remark Normally this should not be modified unless very specific tuning is needed.
+     */
+    static size_type& contextAllocSize() {
+        static size_type size = defaultPoolAllocSize();
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for task object pools.
+     * @return A modifiable reference to the value.
+     * @remark Normally this should not be modified unless very specific tuning is needed.
+     */
+    static size_type& taskAllocSize() {
+        static size_type size = defaultPoolAllocSize();
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for IO task object pools.
+     * @return A modifiable reference to the value.
+     * @remark Normally this should not be modified unless very specific tuning is needed.
+     */
+    static size_type& ioTaskAllocSize() {
+        static size_type size = defaultPoolAllocSize();
+        return size;
+    }
+    
+    /**
+     * @brief Get/set if the default size for task queue pools.
+     * @return A modifiable reference to the value.
+     * @remark Normally this should not be modified unless very specific tuning is needed.
+     */
+    static size_type& queueListAllocSize() {
+        static size_type size = defaultPoolAllocSize();
+        return size;
+    }
+};
+
+}}
+
+#endif //QUANTUM_ALLOCATOR_TRAITS_H

--- a/src/quantum/quantum_stack_allocator.h
+++ b/src/quantum/quantum_stack_allocator.h
@@ -31,7 +31,7 @@ namespace quantum {
 /// @tparam SIZE The size of the stack buffer.
 /// @note This allocator is thread safe. For internal use only.
 template <typename T, unsigned int SIZE>
-struct StackAllocator : public ContiguousPoolManager<T, SIZE>
+struct StackAllocator : public ContiguousPoolManager<T>
 {
     //------------------------------ Typedefs ----------------------------------
     typedef StackAllocator<T, SIZE> this_type;
@@ -40,12 +40,13 @@ struct StackAllocator : public ContiguousPoolManager<T, SIZE>
     typedef const value_type*       const_pointer;
     typedef value_type&             reference;
     typedef const value_type&       const_reference;
-    typedef size_t                  size_type;
+    typedef uint16_t                size_type;
     typedef std::ptrdiff_t          difference_type;
     typedef std::false_type         propagate_on_container_move_assignment;
     typedef std::false_type         propagate_on_container_copy_assignment;
     typedef std::false_type         propagate_on_container_swap;
     typedef std::false_type         is_always_equal;
+    typedef std::true_type          default_constructor;
     typedef std::aligned_storage<sizeof(value_type),
                                  alignof(value_type)> storage_type;
     typedef typename storage_type::type aligned_type;
@@ -56,7 +57,7 @@ struct StackAllocator : public ContiguousPoolManager<T, SIZE>
         typedef StackAllocator<U,SIZE> other;
     };
     //------------------------------- Methods ----------------------------------
-    StackAllocator() : ContiguousPoolManager<T, SIZE>(_buffer)
+    StackAllocator() : ContiguousPoolManager<T>(_buffer, SIZE)
     {}
     StackAllocator(const this_type&) : StackAllocator()
     {}

--- a/src/quantum/quantum_stack_traits.h
+++ b/src/quantum/quantum_stack_traits.h
@@ -22,14 +22,13 @@ namespace Bloomberg {
 namespace quantum {
 
 //==============================================================================================
-//                                 class StackTraits
+//                                 struct StackTraits
 //==============================================================================================
 /// @struct StackParameters.
 /// @brief Allows overrides for the coroutine stack traits which is used internally by the coroutine allocators.
 /// @note See boost::context::stack_traits for details. Typically only the default size should be modified.
 
-class StackTraits {
-public:
+struct StackTraits {
     /// @brief Get/set if the environment defines a limit for the stack size.
     /// @return Modifiable reference.
     static bool& isUnbounded();

--- a/src/quantum/quantum_traits.h
+++ b/src/quantum/quantum_traits.h
@@ -17,11 +17,8 @@
 #define QUANTUM_TRAITS_H
 
 #include <quantum/quantum_stack_traits.h>
-#include <quantum/quantum_coroutine_pool_allocator.h>
+#include <quantum/quantum_allocator.h>
 #include <boost/coroutine2/all.hpp>
-#include <boost/context/stack_traits.hpp>
-#include <boost/coroutine2/pooled_fixedsize_stack.hpp>
-#include <boost/coroutine2/fixedsize_stack.hpp>
 #include <iterator>
 #include <type_traits>
 
@@ -34,23 +31,27 @@ template <class T>
 class Buffer; //fwd declaration
 
 //==============================================================================================
+//                                struct StackTraitsProxy
+//==============================================================================================
+struct StackTraitsProxy {
+    static bool is_unbounded() { return StackTraits::isUnbounded(); }
+    static std::size_t page_size() { return StackTraits::pageSize(); }
+    static std::size_t default_size() { return StackTraits::defaultSize(); }
+    static std::size_t minimum_size() { return StackTraits::minimumSize(); }
+    static std::size_t maximum_size() { return StackTraits::maximumSize(); }
+};
+
+//==============================================================================================
 //                                    struct Traits
 //==============================================================================================
 /// @struct Traits.
 /// @brief Contains definitions for various traits used by this library. For internal use only.
 struct Traits
 {
-    struct StackTraitsProxy {
-        static bool is_unbounded() { return StackTraits::isUnbounded(); }
-        static std::size_t page_size() { return StackTraits::pageSize(); }
-        static std::size_t default_size() { return StackTraits::defaultSize(); }
-        static std::size_t minimum_size() { return StackTraits::minimumSize(); }
-        static std::size_t maximum_size() { return StackTraits::maximumSize(); }
-    };
 #ifndef __QUANTUM_USE_DEFAULT_CORO_ALLOCATOR
-    using CoroStackAllocator = CoroutinePoolAllocatorProxy<StackTraitsProxy, __QUANTUM_DEFAULT_CORO_POOL_ALLOC_SIZE>;
+    using CoroStackAllocator = CoroutinePoolAllocatorProxy<StackTraitsProxy>;
 #else
-    using CoroStackAllocator = boost::context::basic_fixedsize_stack<StackTraitsProxy>;
+    using CoroStackAllocator = BoostAllocator<StackTraitsProxy>;
 #endif
     using BoostCoro = boost::coroutines2::coroutine<int&>;
     using Yield     = typename BoostCoro::pull_type;


### PR DESCRIPTION
Description of changes:
- Refactored allocator logic to allow modification at runtime via statc traits, such as pool sizes.
- Removed template dependency on SIZE for heap allocators.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>