### PR TITLE
Added typedefs for ptr types. Refined the FutureJoiner class

### DIFF
--- a/src/quantum/interface/quantum_icontext_base.h
+++ b/src/quantum/interface/quantum_icontext_base.h
@@ -61,6 +61,8 @@ struct IContextBase
     virtual int setException(std::exception_ptr ex) = 0;
 };
 
+using IContextBasePtr = IContextBase::Ptr;
+
 }}
 
 #endif //DISPATCHER_ICONTEXT_BASE_H

--- a/src/quantum/interface/quantum_icoro_context_base.h
+++ b/src/quantum/interface/quantum_icoro_context_base.h
@@ -76,6 +76,8 @@ struct ICoroContextBase : public virtual IContextBase,
     virtual void waitAll(ICoroSync::Ptr sync) const = 0;
 };
 
+using ICoroContextBasePtr = ICoroContextBase::Ptr;
+
 }}
 
 #endif //QUANTUM_ICORO_CONTEXT_BASE_H

--- a/src/quantum/interface/quantum_icoro_future_base.h
+++ b/src/quantum/interface/quantum_icoro_future_base.h
@@ -54,6 +54,8 @@ struct ICoroFutureBase
                                        std::chrono::milliseconds timeMs) const = 0;
 };
 
+using ICoroFutureBasePtr = ICoroFutureBase::Ptr;
+
 }}
 
 #endif //QUANTUM_ICORO_FUTURE_BASE_H

--- a/src/quantum/interface/quantum_icoro_sync.h
+++ b/src/quantum/interface/quantum_icoro_sync.h
@@ -60,6 +60,8 @@ struct ICoroSync
     virtual void sleep(std::chrono::milliseconds timeMs) = 0;
 };
 
+using ICoroSyncPtr = ICoroSync::Ptr;
+
 }}
 
 #endif //QUANTUM_ICORO_SYNC_H

--- a/src/quantum/interface/quantum_ipromise_base.h
+++ b/src/quantum/interface/quantum_ipromise_base.h
@@ -54,6 +54,8 @@ struct IPromiseBase : public ITerminate
     virtual ICoroFutureBase::Ptr getICoroFutureBase() const = 0;
 };
 
+using IPromiseBasePtr = IPromiseBase::Ptr;
+
 }}
 
 #endif //QUANTUM_IPROMISE_BASE_H

--- a/src/quantum/interface/quantum_iqueue.h
+++ b/src/quantum/interface/quantum_iqueue.h
@@ -63,6 +63,8 @@ struct IQueue : public ITerminate
     virtual bool isIdle() const = 0;
 };
 
+using IQueuePtr = IQueue::Ptr;
+
 #ifndef __QUANTUM_QUEUE_LIST_ALLOC_SIZE
     #define __QUANTUM_QUEUE_LIST_ALLOC_SIZE __QUANTUM_DEFAULT_POOL_ALLOC_SIZE
 #endif

--- a/src/quantum/interface/quantum_itask.h
+++ b/src/quantum/interface/quantum_itask.h
@@ -62,6 +62,9 @@ struct ITask : public ITerminate
     virtual bool isHighPriority() const = 0;
 };
 
+using ITaskPtr = ITask::Ptr;
+using ITaskWeakPtr = ITask::WeakPtr;
+
 }}
 
 #endif //QUANTUM_ITASK_H

--- a/src/quantum/interface/quantum_itask_accessor.h
+++ b/src/quantum/interface/quantum_itask_accessor.h
@@ -39,6 +39,8 @@ struct ITaskAccessor : public ITerminate
     virtual bool isBlocked() = 0;
 };
 
+using ITaskAccessorPtr = ITaskAccessor::Ptr;
+
 }}
 
 #endif //QUANTUM_ITASK_ACCESSOR_H

--- a/src/quantum/interface/quantum_itask_continuation.h
+++ b/src/quantum/interface/quantum_itask_continuation.h
@@ -45,6 +45,9 @@ struct ITaskContinuation : public ITask
     virtual Ptr getErrorHandlerOrFinalTask() = 0;
 };
 
+using ITaskContinuationPtr = ITaskContinuation::Ptr;
+using ITaskContinuationWeakPtr = ITaskContinuation::WeakPtr;
+
 }}
 
 #endif //QUANTUM_ITASKCONTINUATION_H

--- a/src/quantum/interface/quantum_ithread_context_base.h
+++ b/src/quantum/interface/quantum_ithread_context_base.h
@@ -68,6 +68,8 @@ struct IThreadContextBase : public virtual IContextBase
     virtual void waitAll() const = 0;
 };
 
+using IThreadContextBasePtr = IThreadContextBase::Ptr;
+
 }}
 
 #endif //QUANTUM_ITHREAD_CONTEXT_BASE_H

--- a/src/quantum/interface/quantum_ithread_future_base.h
+++ b/src/quantum/interface/quantum_ithread_future_base.h
@@ -51,6 +51,8 @@ struct IThreadFutureBase
     virtual std::future_status waitFor(std::chrono::milliseconds timeMs) const = 0;
 };
 
+using IThreadFutureBasePtr = IThreadFutureBase::Ptr;
+
 }}
 
 #endif //QUANTUM_ITHREAD_FUTURE_BASE_H

--- a/src/quantum/quantum_dispatcher.h
+++ b/src/quantum/quantum_dispatcher.h
@@ -34,6 +34,8 @@ namespace quantum {
 class Dispatcher : public ITerminate
 {
 public:
+    using ContextTag = ThreadContextTag;
+    
     /// @brief Constructor.
     /// @details This will build two thread pools, one used for running parallel coroutines and another
     ///          used for running blocking IO tasks.

--- a/src/quantum/quantum_future_joiner.h
+++ b/src/quantum/quantum_future_joiner.h
@@ -33,53 +33,59 @@ namespace quantum {
 /// @details Instead of waiting for N futures to complete, the user can join them and wait
 ///          on a single future which returns N values.
 /// @tparam T The type returned by the future.
-template <class T>
+template <class DISPATCHER>
 class FutureJoiner
 {
 public:
-    /// @brief Contructs a joiner with a Dispatcher object.
+    /// @brief Construct a joiner with a Dispatcher object.
     /// @param[in] dispatcher The address of a Dispatcher object.
     /// @note Use this constructor when joining N thread futures.
-    explicit FutureJoiner(Dispatcher* dispatcher);
-    
-    /// @brief Contructs a joiner with a ICoroContext object.
-    /// @param[in] dispatcher The coroutine context object.
-    /// @note Use this constructor when joining N coroutine futures.
-    explicit FutureJoiner(CoroContextPtr<T> dispatcher);
+    explicit FutureJoiner(DISPATCHER& dispatcher);
     
     /// @brief Join N thread futures.
     /// @param[in] futures A vector of thread futures.
     /// @return A joined future to wait on.
     /// @note Call this from a thread context only.
+    template <class T>
     ThreadFuturePtr<std::vector<T>> operator()(std::vector<ThreadContextPtr<T>>&& futures);
+    template <class T>
+    ThreadFuturePtr<std::vector<T>> join(std::vector<ThreadContextPtr<T>>&& futures);
     
     /// @brief Join N thread futures.
     /// @param[in] futures A vector of async IO futures.
     /// @return A joined future to wait on.
     /// @note Call this from a thread context only.
+    template <class T>
     ThreadFuturePtr<std::vector<T>> operator()(std::vector<ThreadFuturePtr<T>>&& futures);
+    template <class T>
+    ThreadFuturePtr<std::vector<T>> join(std::vector<ThreadFuturePtr<T>>&& futures);
     
     /// @brief Join N coroutine futures.
     /// @param[in] futures A vector of coroutine futures.
     /// @return A joined future to wait on.
     /// @note Call this from a coroutine context only.
+    template <class T>
     CoroContextPtr<std::vector<T>> operator()(std::vector<CoroContextPtr<T>>&& futures);
+    template <class T>
+    CoroContextPtr<std::vector<T>> join(std::vector<CoroContextPtr<T>>&& futures);
     
     /// @brief Join N coroutine futures.
     /// @param[in] futures A vector of coroutine async IO futures.
     /// @return A joined future to wait on.
     /// @note Call this from a coroutine context only.
+    template <class T>
     CoroContextPtr<std::vector<T>> operator()(std::vector<CoroFuturePtr<T>>&& futures);
+    template <class T>
+    CoroContextPtr<std::vector<T>> join(std::vector<CoroFuturePtr<T>>&& futures);
     
 private:
-    template <template<class> class FUTURE>
+    template <template<class> class FUTURE, class T>
     ThreadFuturePtr<std::vector<T>> join(ThreadContextTag, std::vector<typename FUTURE<T>::Ptr>&& futures);
     
-    template <template<class> class FUTURE>
+    template <template<class> class FUTURE, class T>
     typename FUTURE<std::vector<T>>::Ptr join(CoroContextTag, std::vector<typename FUTURE<T>::Ptr>&& futures);
     
-    Dispatcher*         _threadDispatcher;
-    CoroContextPtr<T>   _coroDispatcher;
+    DISPATCHER& _dispatcher;
 };
 
 }}

--- a/src/quantum/quantum_io_task.h
+++ b/src/quantum/quantum_io_task.h
@@ -80,6 +80,9 @@ private:
     bool                    _isHighPriority;
 };
 
+using IoTaskPtr = IoTask::Ptr;
+using IoTaskWeakPtr = IoTask::WeakPtr;
+
 }}
 
 #include <quantum/impl/quantum_io_task_impl.h>

--- a/src/quantum/quantum_task.h
+++ b/src/quantum/quantum_task.h
@@ -106,6 +106,9 @@ private:
     std::atomic_flag            _terminated;
 };
 
+using TaskPtr = Task::Ptr;
+using TaskWeakPtr = Task::WeakPtr;
+
 }}
 
 #include <quantum/impl/quantum_task_impl.h>

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -1099,7 +1099,7 @@ TEST(FutureJoiner, JoinThreadFutures)
         }));
     }
     
-    std::vector<int> output = quantum::FutureJoiner<int>(&DispatcherSingleton::instance())(std::move(futures))->get();
+    std::vector<int> output = FutureJoiner<Dispatcher>(DispatcherSingleton::instance()).join<int>(std::move(futures))->get();
     EXPECT_EQ(output, std::vector<int>({0,1,2,3,4,5,6,7,8,9}));
 }
 
@@ -1107,7 +1107,7 @@ TEST(FutureJoiner, JoinCoroFutures)
 {
     std::vector<int> output;
     
-    DispatcherSingleton::instance().post([&output](CoroContext<int>::Ptr ctx)->int {
+    DispatcherSingleton::instance().post<double>([&output](CoroContext<double>::Ptr ctx)->int {
         std::vector<quantum::CoroContext<int>::Ptr> futures;
         for (int i = 0; i < 10; ++i) {
             futures.push_back(ctx->post<int>([i](CoroContext<int>::Ptr ctx2)->int {
@@ -1115,7 +1115,7 @@ TEST(FutureJoiner, JoinCoroFutures)
                 return ctx2->set(i);
             }));
         }
-        output = quantum::FutureJoiner<int>(ctx)(std::move(futures))->get(ctx);
+        output = FutureJoiner<CoroContext<double>>(*ctx).join<int>(std::move(futures))->get(ctx);
         return ctx->set(0);
     })->get();
     


### PR DESCRIPTION
* Added typedefs for ptr types. 
* Refined the `FutureJoiner` class to allow the joined type to differ from the dispatcher type

Signed-off-by: Alexander Damian <adamian@bloomberg.net>