### PR TITLE
Use known batch size to better optimize the array.

### DIFF
--- a/src/quantum/impl/quantum_util_impl.h
+++ b/src/quantum/impl/quantum_util_impl.h
@@ -142,6 +142,7 @@ int Util::forEachBatchCoro(CoroContextPtr<std::vector<std::vector<RET>>> ctx,
         asyncResults.emplace_back(ctx->template post<std::vector<RET>>([inputIt, batchSize, &func](CoroContextPtr<std::vector<RET>> ctx)->int
         {
             std::vector<RET> result;
+            result.reserve(batchSize);
             auto it = inputIt;
             for (size_t j = 0; j < batchSize; ++j, ++it)
             {


### PR DESCRIPTION
Use the known ```batchSize``` to atleast reserve the vector ```result```, so that we can save on re-allocation costs.