### PR TITLE
Fix re-ordering of coroutines

### DIFF
--- a/src/quantum/quantum_task_queue.h
+++ b/src/quantum/quantum_task_queue.h
@@ -99,6 +99,7 @@ private:
     std::atomic_bool                    _isInterrupted;
     std::atomic_bool                    _isIdle;
     std::atomic_flag                    _terminated;
+    bool                                _isAdvanced;
     QueueStatistics                     _stats;
 };
 


### PR DESCRIPTION
This was introduced by the previous commit and needs to be written in a slightly different way. The current issue is that when `std::prev()` is called, another thread could be posting a new coroutine which would get inserted before the next one in the chain (i.e. before `advance()` is called)

Signed-off-by: Alexander Damian <adamian@bloomberg.net>