### PR TITLE
Simplified buffer type SFINAE argument.

### DIFF
--- a/src/quantum/impl/quantum_buffer_impl.h
+++ b/src/quantum/impl/quantum_buffer_impl.h
@@ -22,14 +22,15 @@
 namespace Bloomberg {
 namespace quantum {
 
-template <class T>
-Buffer<T>::Buffer() :
+template <class T, class ALLOCATOR>
+Buffer<T,ALLOCATOR>::Buffer(const ALLOCATOR& allocator) :
+    _buffer(allocator),
     _isClosed(false)
 {}
 
-template <class T>
+template <class T, class ALLOCATOR>
 template <class V>
-BufferStatus Buffer<T>::push(V&& value)
+BufferStatus Buffer<T,ALLOCATOR>::push(V&& value)
 {
     if (_isClosed)
     {
@@ -39,8 +40,8 @@ BufferStatus Buffer<T>::push(V&& value)
     return BufferStatus::DataPosted;
 }
 
-template <class T>
-BufferStatus Buffer<T>::pull(T& value)
+template <class T, class ALLOCATOR>
+BufferStatus Buffer<T,ALLOCATOR>::pull(T& value)
 {
     if (_buffer.empty())
     {
@@ -51,20 +52,20 @@ BufferStatus Buffer<T>::pull(T& value)
     return BufferStatus::DataReceived;
 }
 
-template <class T>
-void Buffer<T>::close()
+template <class T, class ALLOCATOR>
+void Buffer<T,ALLOCATOR>::close()
 {
     _isClosed = true;
 }
 
-template <class T>
-size_t Buffer<T>::size()
+template <class T, class ALLOCATOR>
+size_t Buffer<T,ALLOCATOR>::size()
 {
     return _buffer.size();
 }
 
-template <class T>
-bool Buffer<T>::empty()
+template <class T, class ALLOCATOR>
+bool Buffer<T,ALLOCATOR>::empty()
 {
     return _buffer.empty();
 }

--- a/src/quantum/impl/quantum_shared_state_impl.h
+++ b/src/quantum/impl/quantum_shared_state_impl.h
@@ -275,7 +275,7 @@ V SharedState<T>::pull(bool& isBufferClosed)
     //========= LOCKED SCOPE =========
     Mutex::Guard lock(_mutex);
     BufferStatus status;
-    V out{};
+    V out;
     isBufferClosed = true;
     _cond.wait(_mutex, [&status, &out, this]()->bool
     {
@@ -299,7 +299,7 @@ V SharedState<T>::pull(ICoroSync::Ptr sync, bool& isBufferClosed)
     //========= LOCKED SCOPE =========
     Mutex::Guard lock(sync, _mutex);
     BufferStatus status;
-    typename BUF::ValueType out;
+    V out;
     isBufferClosed = true;
     _cond.wait(sync, _mutex, [&status, &out, this]()->bool
     {
@@ -317,7 +317,7 @@ V SharedState<T>::pull(ICoroSync::Ptr sync, bool& isBufferClosed)
 }
 
 template <class T>
-template <class BUF, class>
+template <class BUF, class V>
 int SharedState<T>::closeBuffer()
 {
     //========= LOCKED SCOPE =========

--- a/src/quantum/interface/quantum_icoro_context.h
+++ b/src/quantum/interface/quantum_icoro_context.h
@@ -114,7 +114,7 @@ struct ICoroContext : public ICoroContextBase
     /// @param[in] value Value to push at the end of the buffer.
     /// @note Method available for buffered futures only. Never blocks. Once the buffer is closed, no more Push
     ///       operations are allowed.
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     void push(V &&value);
     
     /// @brief Pull a single value from the future buffer.
@@ -124,7 +124,7 @@ struct ICoroContext : public ICoroContextBase
     /// @param[out] isBufferClosed Indicates if this buffer is closed and no more Pull operations are allowed on it.
     /// @return The next value pulled out from the front of the buffer.
     /// @note Method available for buffered futures only. Blocks until one value is retrieved from the buffer.
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     V pull(ICoroSync::Ptr sync, bool& isBufferClosed);
     
     /// @brief Close a promise buffer.
@@ -132,7 +132,7 @@ struct ICoroContext : public ICoroContextBase
     /// @note Once closed no more Pushes can be made into the buffer. The corresponding future can still Pull values until
     ///       the buffer is empty.
     /// @return 0 on success.
-    template <class BUF = RET, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     int closeBuffer();
     
     /// @brief Returns the number of underlying coroutine threads as specified in the dispatcher constructor.

--- a/src/quantum/interface/quantum_icoro_future.h
+++ b/src/quantum/interface/quantum_icoro_future.h
@@ -59,7 +59,7 @@ struct ICoroFuture : public ICoroFutureBase
     /// @param[out] isBufferClosed Indicates if this buffer is closed and no more Pull operations are allowed on it.
     /// @return The next value pulled out from the front of the buffer.
     /// @note Method available for buffered futures only. Blocks until one value is retrieved from the buffer.
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     V pull(ICoroSync::Ptr sync, bool& isBufferClosed);
 };
 

--- a/src/quantum/interface/quantum_icoro_promise.h
+++ b/src/quantum/interface/quantum_icoro_promise.h
@@ -62,7 +62,7 @@ struct ICoroPromise : public Traits::DerivedFrom<PROMISE<T>,
     /// @param[in] value Value to push at the end of the buffer.
     /// @note Method available for buffered futures only. Once the buffer is closed, no more Push
     ///       operations are allowed.
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     void push(ICoroSync::Ptr sync, V &&value);
     
     /// @brief Close a promise buffer.
@@ -70,7 +70,7 @@ struct ICoroPromise : public Traits::DerivedFrom<PROMISE<T>,
     /// @note Once closed no more Pushes can be made into the buffer. The corresponding future can still Pull values until
     ///       the buffer is empty.
     /// @return 0 on success.
-    template <class BUF = T, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = T, class V = BufferValue<BUF>>
     int closeBuffer();
 };
 

--- a/src/quantum/interface/quantum_ithread_context.h
+++ b/src/quantum/interface/quantum_ithread_context.h
@@ -121,7 +121,7 @@ struct IThreadContext : public IThreadContextBase
     /// @param[in] value Value to push at the end of the buffer.
     /// @note Method available for buffered futures only. Never blocks. Once the buffer is closed, no more Push
     ///       operations are allowed.
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     void push(V &&value);
     
     /// @brief Pull a single value from the future buffer.
@@ -130,7 +130,7 @@ struct IThreadContext : public IThreadContextBase
     /// @param[out] isBufferClosed Indicates if this buffer is closed and no more Pull operations are allowed on it.
     /// @return The next value pulled out from the front of the buffer.
     /// @note Method available for buffered futures only. Blocks until one value is retrieved from the buffer.
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     V pull(bool& isBufferClosed);
     
     /// @brief Close a promise buffer.
@@ -138,7 +138,7 @@ struct IThreadContext : public IThreadContextBase
     /// @note Once closed no more Pushes can be made into the buffer. The corresponding future can still Pull values until
     ///       the buffer is empty.
     /// @return 0 on success.
-    template <class BUF = RET, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     int closeBuffer();
     
     /// @brief Returns the number of underlying coroutine threads as specified in the dispatcher constructor.

--- a/src/quantum/interface/quantum_ithread_future.h
+++ b/src/quantum/interface/quantum_ithread_future.h
@@ -56,7 +56,7 @@ struct IThreadFuture : public IThreadFutureBase
     /// @param[out] isBufferClosed Indicates if this buffer is closed and no more Pull operations are allowed on it.
     /// @return The next value pulled out from the front of the buffer.
     /// @note Method available for buffered futures only. Blocks until one value is retrieved from the buffer.
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     V pull(bool& isBufferClosed);
 };
 

--- a/src/quantum/interface/quantum_ithread_promise.h
+++ b/src/quantum/interface/quantum_ithread_promise.h
@@ -61,7 +61,7 @@ struct IThreadPromise : public Traits::DerivedFrom<PROMISE<T>,
     /// @param[in] value Value to push at the end of the buffer.
     /// @note Method available for buffered futures only. Once the buffer is closed, no more Push
     ///       operations are allowed.
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     void push(V &&value);
     
     /// @brief Close a promise buffer.
@@ -69,7 +69,7 @@ struct IThreadPromise : public Traits::DerivedFrom<PROMISE<T>,
     /// @note Once closed no more Pushes can be made into the buffer. The corresponding future can still Pull values until
     ///       the buffer is empty.
     /// @return 0 on success.
-    template <class BUF = T, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = T, class V = BufferValue<BUF>>
     int closeBuffer();
 };
 

--- a/src/quantum/quantum_buffer.h
+++ b/src/quantum/quantum_buffer.h
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <deque>
 #include <quantum/quantum_future_state.h>
+#include <quantum/quantum_traits.h>
 
 namespace Bloomberg {
 namespace quantum {
@@ -44,14 +45,14 @@ enum class BufferStatus
 ///        by a producer(s) and pulled-out (read) by a consumer(s).
 /// @tparam T Type of the contained value.
 /// @warning This class is not thread safe.
-template <class T>
+template <class T, class ALLOCATOR>
 class Buffer
 {
 public:
     using ValueType = T; ///< Type definition for the contained value.
     
     /// @brief Constructor
-    Buffer();
+    Buffer(const ALLOCATOR& alloc = ALLOCATOR());
     
     /// @brief Pushes a value at the end of the buffer. This increases the size of the buffer by one.
     /// @tparam V Type of the contained value. Must be inferred and always equal to T.
@@ -78,8 +79,8 @@ public:
     bool empty();
     
 private:
-    std::deque<T>   _buffer;
-    bool            _isClosed;
+    std::deque<T,ALLOCATOR>     _buffer;
+    bool                        _isClosed;
 };
 
 }}

--- a/src/quantum/quantum_context.h
+++ b/src/quantum/quantum_context.h
@@ -120,19 +120,19 @@ public:
     template <class V = RET>
     int set(ICoroSync::Ptr sync, V&& value);
     
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     void push(V &&value);
     
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     void push(ICoroSync::Ptr sync, V &&value);
     
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     V pull(bool& isBufferClosed);
     
-    template <class BUF = RET, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     V pull(ICoroSync::Ptr sync, bool& isBufferClosed);
     
-    template <class BUF = RET, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = RET, class V = BufferValue<BUF>>
     int closeBuffer();
     
     template <class OTHER_RET>

--- a/src/quantum/quantum_future.h
+++ b/src/quantum/quantum_future.h
@@ -53,7 +53,7 @@ public:
     T get() final;
     const T& getRef() const final;
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     V pull(bool& isBufferClosed);
     
     //ICoroFutureBase
@@ -64,7 +64,7 @@ public:
     T get(ICoroSync::Ptr sync) final;
     const T& getRef(ICoroSync::Ptr sync) const final;
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     V pull(ICoroSync::Ptr sync, bool& isBufferClosed);
     
     //===================================

--- a/src/quantum/quantum_promise.h
+++ b/src/quantum/quantum_promise.h
@@ -60,17 +60,17 @@ public:
     template <class V = T>
     int set(V&& value);
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     void push(V &&value);
     
     //ICoroPromise
     template <class V = T>
     int set(ICoroSync::Ptr sync, V&& value);
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     void push(ICoroSync::Ptr sync, V &&value);
     
-    template <class BUF = T, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = T, class V = BufferValue<BUF>>
     int closeBuffer();
     
     //===================================

--- a/src/quantum/quantum_shared_state.h
+++ b/src/quantum/quantum_shared_state.h
@@ -76,19 +76,19 @@ public:
     //=========================================================================
     //                         Buffered future access
     //=========================================================================
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     void push(V&& value);
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     void push(ICoroSync::Ptr sync, V&& value);
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     V pull(bool& isBufferClosed);
     
-    template <class BUF = T, class V = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType>
+    template <class BUF = T, class V = BufferValue<BUF>>
     V pull(ICoroSync::Ptr sync, bool& isBufferClosed);
     
-    template <class BUF = T, class = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = T, class V = BufferValue<BUF>>
     int closeBuffer();
     
 private:
@@ -102,7 +102,7 @@ private:
     
     bool stateHasChanged() const;
     
-    template <class BUF = T, typename = std::enable_if_t<Traits::IsBuffer<BUF>::value>>
+    template <class BUF = T, class V = BufferValue<BUF>>
     bool bufferStateHasChanged(BufferStatus status) const;
     
     // ============================= MEMBERS ==============================

--- a/src/quantum/quantum_traits.h
+++ b/src/quantum/quantum_traits.h
@@ -27,7 +27,7 @@ namespace quantum {
 
 #define UNUSED(x) (void)(x) //remove compiler warnings
 
-template <class T>
+template <class T, class ALLOCATOR = std::allocator<T>>
 class Buffer; //fwd declaration
 
 //==============================================================================================
@@ -78,6 +78,9 @@ struct Traits
         operator B&() { return static_cast<D&>(static_cast<THIS&>(*this)); }
     };
 };
+
+template <class BUF>
+using BufferValue = typename std::enable_if_t<Traits::IsBuffer<BUF>::value, BUF>::ValueType;
 
 }}
 

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -310,7 +310,7 @@ TEST(ParamtersTest, CheckParameterPassingInCoroutines)
         return ctx->set(0);
     };
     
-    DispatcherSingleton::instance().post(func, a, str, std::move(str2), std::move(nc), &dbl)->get();
+    DispatcherSingleton::instance().post(func, int(a), str, std::move(str2), std::move(nc), &dbl)->get();
     
     //Validate values
     EXPECT_EQ(5, a);


### PR DESCRIPTION
Simplified buffer type SFINAE argument.
Provided allocator template parameter to the `Buffer` class.
Fixed pass-by-value argument in test case. 

Signed-off-by: Alexander Damian <adamian@bloomberg.net>