### PR TITLE
Using quantum dispatcher for sequencing tasks based on sequence key

### DIFF
--- a/src/quantum/quantum.h
+++ b/src/quantum/quantum.h
@@ -70,5 +70,6 @@
 #include <quantum/quantum_traits.h>
 #include <quantum/quantum_util.h>
 #include <quantum/quantum_yielding_thread.h>
+#include <quantum/util/quantum_sequencer.h>
 
 #endif //QUANTUM_H

--- a/src/quantum/util/impl/quantum_sequencer_configuration_impl.h
+++ b/src/quantum/util/impl/quantum_sequencer_configuration_impl.h
@@ -1,0 +1,120 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+//NOTE: DO NOT INCLUDE DIRECTLY
+
+//##############################################################################################
+//#################################### IMPLEMENTATIONS #########################################
+//##############################################################################################
+
+#include <quantum/util/quantum_sequencer_key_statistics.h>
+
+namespace Bloomberg {
+namespace quantum {
+
+struct SequencerKeyData
+{
+    ICoroContextBasePtr context;
+    SequencerKeyStatisticsWriter stats;
+};
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+void
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::setControlQueueId(int controlQueueId)
+{
+    _controllerQueueId = controlQueueId;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+int
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::getControlQueueId() const
+{
+    return _controllerQueueId;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+void
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::setBucketCount(size_t bucketCount)
+{
+    _bucketCount = bucketCount;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+size_t
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::getBucketCount() const
+{
+    return _bucketCount;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+void
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::setHash(const Hash& hash)
+{
+    _hash = hash;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+const Hash&
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::getHash() const
+{
+    return _hash;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+void
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::setKeyEqual(const KeyEqual& keyEqual)
+{
+    _keyEqual = keyEqual;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+const KeyEqual&
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::getKeyEqual() const
+{
+    return _keyEqual;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+void
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::setAllocator(const Allocator& allocator)
+{
+    _allocator = allocator;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+const Allocator&
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::getAllocator() const
+{
+    return _allocator;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+void 
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::setExceptionCallback(
+    const typename SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& 
+    exceptionCallback)
+
+{
+    _exceptionCallback = exceptionCallback;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+const typename SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& 
+SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>::getExceptionCallback() const
+{
+    return _exceptionCallback;
+}
+
+}}

--- a/src/quantum/util/impl/quantum_sequencer_impl.h
+++ b/src/quantum/util/impl/quantum_sequencer_impl.h
@@ -1,0 +1,515 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+//NOTE: DO NOT INCLUDE DIRECTLY
+
+//##############################################################################################
+//#################################### IMPLEMENTATIONS #########################################
+//##############################################################################################
+
+#include <stdexcept>
+
+namespace Bloomberg {
+namespace quantum {
+    
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::Sequencer(Dispatcher& dispatcher,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::Configuration& configuration) :
+    _dispatcher(dispatcher),
+    _controllerQueueId(configuration.getControlQueueId()),
+    _universalContext(),
+    _contexts(configuration.getBucketCount(),
+              configuration.getHash(),
+              configuration.getKeyEqual(),
+              configuration.getAllocator()),
+    _exceptionCallback(configuration.getExceptionCallback())
+{
+    if (_controllerQueueId <= (int)IQueue::QueueId::Any || _controllerQueueId >= _dispatcher.getNumCoroutineThreads())
+    {
+        throw std::out_of_range("Allowed range is 0 <= controllerQueueId < _dispatcher.getNumCoroutineThreads()");
+    }
+}
+    
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+    const SequenceKey& sequenceKey,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    _dispatcher.post<int>(_controllerQueueId,
+                          false,
+                          &singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          (int)IQueue::QueueId::Any,
+                          false,
+                          nullptr,
+                          _exceptionCallback,
+                          SequenceKey(sequenceKey),
+                          _contexts,
+                          _universalContext,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postEx(
+    int queueId,
+    bool isHighPriority,
+    void* opaque,
+    const SequenceKey& sequenceKey,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    if (queueId < (int)IQueue::QueueId::Any)
+    {
+        throw std::runtime_error("Invalid IO queue id");
+    }
+
+    _dispatcher.post<int>(_controllerQueueId,
+                          false,
+                          &singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          queueId,
+                          isHighPriority,
+                          std::move(opaque),
+                          _exceptionCallback,
+                          SequenceKey(sequenceKey),
+                          _contexts,
+                          _universalContext,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
+}
+ 
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+    const std::vector<SequenceKey>& sequenceKeys,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    _dispatcher.post<int>(_controllerQueueId,
+                          false,
+                          &multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          (int)IQueue::QueueId::Any,
+                          false,
+                          nullptr,
+                          _exceptionCallback,
+                          std::vector<SequenceKey>(sequenceKeys),
+                          _contexts,
+                          _universalContext,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postEx(
+    int queueId,
+    bool isHighPriority,
+    void* opaque,
+    const std::vector<SequenceKey>& sequenceKeys,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    if (queueId < (int)IQueue::QueueId::Any)
+    {
+        throw std::runtime_error("Invalid IO queue id");
+    }
+    _dispatcher.post<int>(_controllerQueueId,
+                          false,
+                          &multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          queueId,
+                          isHighPriority,
+                          std::move(opaque),
+                          _exceptionCallback,
+                          std::vector<SequenceKey>(sequenceKeys),
+                          _contexts,
+                          _universalContext,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
+}
+ 
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(FUNC&& func, ARGS&&... args)
+{
+    _dispatcher.post<int>(_controllerQueueId,
+                          false,
+                          &universalTaskScheduler<FUNC, ARGS...>,
+                          (int)IQueue::QueueId::Any,
+                          false,
+                          nullptr,
+                          _exceptionCallback,
+                          _contexts,
+                          _universalContext,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAllEx(
+    int queueId,
+    bool isHighPriority,
+    void* opaque,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    if (queueId < (int)IQueue::QueueId::Any)
+    {
+        throw std::runtime_error("Invalid IO queue id");
+    }
+    _dispatcher.post<int>(_controllerQueueId,
+                          false,
+                          &universalTaskScheduler<FUNC, ARGS...>,
+                          queueId,
+                          isHighPriority,
+                          std::move(opaque),
+                          _exceptionCallback,
+                          _contexts,
+                          _universalContext,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+size_t
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::trimSequenceKeys()
+{
+    auto trimFunc = [this](CoroContextPtr<size_t> ctx)->int
+    {
+        for (typename ContextMap::iterator it = _contexts.begin(); it != _contexts.end();)
+        {
+            typename ContextMap::iterator thisIt = it++;
+            if (canTrimContext(ctx, thisIt->second.context))
+            {
+                _contexts.erase(thisIt);
+            }
+        }
+        return ctx->set(_contexts.size());
+    };
+    return _dispatcher.post<size_t>(_controllerQueueId, true, trimFunc)->get();
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+SequencerKeyStatistics
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getStatistics(const SequenceKey& sequenceKey)
+{
+    auto statsFunc = [this, sequenceKey](CoroContextPtr<SequencerKeyStatistics> ctx)->int
+    {
+        SequencerKeyStatisticsWriter stats;
+        typename ContextMap::iterator ctxIt = _contexts.find(sequenceKey);
+        if (ctxIt == _contexts.end())
+        {
+            return ctx->set(SequencerKeyStatistics());
+        }
+        return ctx->set(SequencerKeyStatistics(ctxIt->second.stats));
+    };
+    return _dispatcher.post<SequencerKeyStatistics>(_controllerQueueId, true, statsFunc)->get();
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+SequencerKeyStatistics
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getStatistics()
+{
+    auto statsFunc = [this](CoroContextPtr<SequencerKeyStatistics> ctx)->int
+    {
+        return ctx->set(SequencerKeyStatistics(_universalContext.stats));
+    };
+    return _dispatcher.post<SequencerKeyStatistics>(_controllerQueueId, true, statsFunc)->get();
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+size_t
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getSequenceKeyCount()
+{
+    auto statsFunc = [this](CoroContextPtr<size_t> ctx)->int
+    {
+        return ctx->set(_contexts.size());
+    };
+    return _dispatcher.post<size_t>(_controllerQueueId, true, statsFunc)->get();
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+int
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::waitForTwoDependents(
+    CoroContextPtr<int> ctx,
+    ICoroContextBasePtr dependent,
+    ICoroContextBasePtr universalContext,
+    SequencerKeyStatisticsWriter& stats,
+    void* opaque,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
+        exceptionCallback,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    // wait until all the dependents are done
+    if (dependent)
+    {
+        dependent->wait(ctx);
+    }
+    if (universalContext)
+    {
+        universalContext->wait(ctx);
+    }
+
+    // statistics update action to be called after the func, even if func throws
+    auto updateStatsAction = [&stats]()
+    {
+        // update the dependent's stats only, because the task is associated with the non-universal key
+        stats.decrementPendingTaskCount();
+    };
+    callPosted(ctx, 
+               updateStatsAction, 
+               opaque, 
+               exceptionCallback, 
+               std::forward<FUNC>(func), 
+               std::forward<ARGS>(args)...);
+    return 0;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+int
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::waitForDependents(
+    CoroContextPtr<int> ctx,
+    std::vector<std::pair<ICoroContextBasePtr, SequencerKeyStatisticsWriter*>>&& dependents,
+    void* opaque,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
+        exceptionCallback,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    // wait until all the dependents are done
+    for (const auto& dependent : dependents)
+    {
+        if (dependent.first)
+        {
+            dependent.first->wait(ctx);
+        }
+    }
+
+    // statistics update action to be called after the func, even if func throws
+    auto updateStatsAction = [&dependents]()
+    {
+        // update the pending statistics for the passed tasks
+        for (auto& dependent : dependents)
+        {
+            if (dependent.second)
+            {
+                dependent.second->decrementPendingTaskCount();
+            }
+        }
+    };
+    callPosted(ctx, 
+               updateStatsAction, 
+               opaque, 
+               exceptionCallback, 
+               std::forward<FUNC>(func), 
+               std::forward<ARGS>(args)...);
+    return 0;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+int
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::singleSequenceKeyTaskScheduler(
+    CoroContextPtr<int> ctx,
+    int queueId,
+    bool isHighPriority,
+    void* opaque,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
+        exceptionCallback,
+    SequenceKey&& sequenceKey,
+    ContextMap& contexts,
+    SequencerKeyData& universalContext,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    // find the dependent
+    typename ContextMap::iterator contextIt = contexts.find(sequenceKey);
+    if (contextIt == contexts.end())
+    {
+        contextIt = contexts.emplace(sequenceKey, SequencerKeyData()).first;
+    }
+    contextIt->second.stats.incrementPostedTaskCount();
+    contextIt->second.stats.incrementPendingTaskCount();
+
+    // save the context as the last for this sequenceKey
+    contextIt->second.context = ctx->post<int>(queueId,
+                                               isHighPriority,
+                                               &waitForTwoDependents<FUNC, ARGS...>,
+                                               ICoroContextBasePtr(contextIt->second.context),
+                                               ICoroContextBasePtr(universalContext.context),
+                                               contextIt->second.stats,
+                                               std::move(opaque),
+                                               exceptionCallback,
+                                               std::forward<FUNC>(func),
+                                               std::forward<ARGS>(args)...);
+    return 0;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+int
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::multiSequenceKeyTaskScheduler(
+    CoroContextPtr<int> ctx,
+    int queueId,
+    bool isHighPriority,
+    void* opaque,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
+        exceptionCallback,
+    std::vector<SequenceKey>&& sequenceKeys,
+    ContextMap& contexts,
+    SequencerKeyData& universalContext,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    // construct the dependent collection
+    std::vector<std::pair<ICoroContextBasePtr, SequencerKeyStatisticsWriter*>> dependents;
+    dependents.reserve(sequenceKeys.size() + 1);
+    dependents.push_back(std::make_pair(universalContext.context, nullptr));
+    for (const SequenceKey& sequenceKey : sequenceKeys)
+    {
+        auto taskIt = contexts.find(sequenceKey);
+        if (taskIt != contexts.end())
+        {
+            // update the depedent stats only
+            taskIt->second.stats.incrementPostedTaskCount();
+            taskIt->second.stats.incrementPendingTaskCount();
+            // pass the pointer to the stats to the wait function so that it updates them too
+            dependents.push_back(std::make_pair(taskIt->second.context, &taskIt->second.stats));
+        }
+    }
+    ICoroContextBasePtr newCtx = ctx->post<int>(queueId,
+                                                isHighPriority,
+                                                &waitForDependents<FUNC, ARGS...>,
+                                                std::move(dependents),
+                                                std::move(opaque),
+                                                exceptionCallback,
+                                                std::forward<FUNC>(func),
+                                                std::forward<ARGS>(args)...);
+    // save the context as the last for each sequenceKey
+    for (const SequenceKey& sequenceKey : sequenceKeys)
+    {
+        contexts[sequenceKey].context = newCtx;
+    }
+    return 0;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FUNC, class ... ARGS>
+int
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::universalTaskScheduler(
+    CoroContextPtr<int> ctx,
+    int queueId,
+    bool isHighPriority,
+    void* opaque,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
+        exceptionCallback,
+    ContextMap& contexts,
+    SequencerKeyData& universalContext,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    // construct the dependent collection
+    std::vector<std::pair<ICoroContextBasePtr, SequencerKeyStatisticsWriter*>> dependents;
+    dependents.reserve(contexts.size() + 1);
+    dependents.push_back(std::make_pair(universalContext.context, &universalContext.stats));
+    for(typename ContextMap::iterator ctxIt = contexts.begin(); ctxIt != contexts.end(); )
+    {
+        typename ContextMap::iterator thisIt = ctxIt++;
+        // since we're accessing all the contexts here, check if can trim some of them
+        if (canTrimContext(ctx, thisIt->second.context))
+        {
+            contexts.erase(thisIt);
+        }
+        else
+        {
+            dependents.push_back(std::make_pair(thisIt->second.context, nullptr));
+        }
+    }
+    // update the universal stats only
+    universalContext.stats.incrementPostedTaskCount();
+    universalContext.stats.incrementPendingTaskCount();
+
+    // post the task and save the context as the last for the unviersal sequenceKey
+    universalContext.context = ctx->post<int>(queueId,
+                                              isHighPriority,
+                                              &waitForDependents<FUNC, ARGS...>,
+                                              std::move(dependents),
+                                              std::move(opaque),
+                                              exceptionCallback,
+                                              std::forward<FUNC>(func),
+                                              std::forward<ARGS>(args)...);
+    return 0;
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+template <class FINAL_ACTION, class FUNC, class ... ARGS>
+void
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::callPosted(
+    CoroContextPtr<int> ctx,
+    const FINAL_ACTION& finalAction,
+    void* opaque,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
+        exceptionCallback,
+    FUNC&& func,
+    ARGS&&... args)
+{
+    auto finalActionWrapper = [&finalAction](int*)
+    {
+        // this should not throw anything outside
+        try
+        {
+            finalAction();
+        }
+        catch(...) {}
+    };
+    // make sure the final action is eventually called 
+    int dummy = 0;
+    std::unique_ptr<int, decltype(finalActionWrapper)&> finalActionCaller(&dummy, finalActionWrapper);
+    try
+    {
+        func(ctx, std::forward<ARGS>(args)...);
+    }
+    catch(std::exception& ex)
+    {
+        if (exceptionCallback)
+        {
+            exceptionCallback(std::current_exception(), opaque);
+        }
+        throw;
+    }
+}
+
+template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
+bool
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::canTrimContext(const ICoroContextBasePtr& ctx,
+                                                                  const ICoroContextBasePtr& ctxToValidate)
+{
+    return !ctxToValidate || !ctxToValidate->valid() ||
+        ctxToValidate->waitFor(ctx, std::chrono::milliseconds(0)) == std::future_status::ready;
+}
+
+
+}}

--- a/src/quantum/util/impl/quantum_sequencer_key_statistics_impl.h
+++ b/src/quantum/util/impl/quantum_sequencer_key_statistics_impl.h
@@ -1,0 +1,90 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+//NOTE: DO NOT INCLUDE DIRECTLY
+
+//##############################################################################################
+//#################################### IMPLEMENTATIONS #########################################
+//##############################################################################################
+
+namespace Bloomberg {
+namespace quantum {
+
+inline
+SequencerKeyStatistics::SequencerKeyStatistics(const SequencerKeyStatistics& that) :
+    _postedTaskCount(that._postedTaskCount),
+    _pendingTaskCount(that._pendingTaskCount.load())
+{
+}
+
+inline
+SequencerKeyStatistics::SequencerKeyStatistics(SequencerKeyStatistics&& that) :
+    _postedTaskCount(std::move(that._postedTaskCount)),
+    _pendingTaskCount(that._pendingTaskCount.load())
+{
+}
+
+inline
+SequencerKeyStatistics& SequencerKeyStatistics::operator = (SequencerKeyStatistics&& that)
+{
+    _postedTaskCount = std::move(that._postedTaskCount);
+    _pendingTaskCount = that._pendingTaskCount.load();
+    return *this;
+}
+
+inline
+SequencerKeyStatistics& SequencerKeyStatistics::operator = (const SequencerKeyStatistics& that)
+{
+    _postedTaskCount = that._postedTaskCount;
+    _pendingTaskCount = _pendingTaskCount.load();
+    return *this;
+}
+ 
+inline
+size_t
+SequencerKeyStatistics::getPostedTaskCount() const
+{
+    return _postedTaskCount;
+}
+
+inline
+size_t
+SequencerKeyStatistics::getPendingTaskCount() const
+{
+    return _pendingTaskCount;
+}
+ 
+inline
+void
+SequencerKeyStatisticsWriter::incrementPostedTaskCount()
+{
+    ++_postedTaskCount;
+}
+ 
+inline
+void
+SequencerKeyStatisticsWriter::incrementPendingTaskCount()
+{
+    ++_pendingTaskCount;
+}
+
+inline
+void
+SequencerKeyStatisticsWriter::decrementPendingTaskCount()
+{
+    --_pendingTaskCount;
+}
+ 
+}}

--- a/src/quantum/util/quantum_sequencer.h
+++ b/src/quantum/util/quantum_sequencer.h
@@ -1,0 +1,262 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef QUANTUM_SEQUENCER_H
+#define QUANTUM_SEQUENCER_H
+
+#include <quantum/quantum_dispatcher.h>
+#include <quantum/interface/quantum_ithread_context_base.h>
+#include <quantum/util/quantum_sequencer_configuration.h>
+#include <quantum/util/quantum_sequencer_key_statistics.h>
+#include <vector>
+#include <unordered_map>
+ 
+namespace Bloomberg {
+namespace quantum {
+ 
+//==============================================================================================
+//                                      class Sequencer
+//==============================================================================================
+/// @class Sequencer.
+/// @brief Implementation of a key-based task sequencing with quantum.
+/// @tparam SequenceKey Type of the key based that sequenced tasks are associated with
+/// @tparam Hash Hash-function used for storing instances of SequncerKey in hash maps
+/// @tparam KeyEqual The equal-function used for storing instances of SequncerKey in hash maps
+/// @tparam Allocator The allocator used for storing instances of SequncerKey in hash maps
+    
+template <class SequenceKey,
+          class Hash = std::hash<SequenceKey>,
+          class KeyEqual = std::equal_to<SequenceKey>,
+          class Allocator = std::allocator<std::pair<const SequenceKey, SequencerKeyData>>>
+class Sequencer
+{
+public:
+    /// @brief Configuration class for Sequencer
+    using Configuration = SequencerConfiguration<SequenceKey, Hash, KeyEqual, Allocator>;
+
+    /// @brief Constructor.
+    /// @param[in] dispatcher Dispatcher for all task dispatching
+    /// @param[in] configuration the configuration object
+    Sequencer(Dispatcher& dispatcher, const Configuration& configuration = Configuration());
+
+    /// @brief Post a coroutine to run asynchronously.
+    /// @details This method will post the coroutine on any thread available
+    ///          (@see Dispatcher::post for more details).
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    ///              (@see Dispatcher::post for more details).
+    /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
+    /// @param[in] sequenceKey SequenceKey object that the posted task is associated with
+    /// @param[in] func Callable object.
+    /// @param[in] args Variable list of arguments passed to the callable object.
+    /// @note This function is non-blocking and returns immediately.
+    template <class FUNC, class ... ARGS>
+    void
+    post(const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
+
+    /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    ////             (@see Dispatcher::post for more details).
+    /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
+    /// @param[in] queueId Id of the queue where this coroutine should run. Note that the user can
+    ///                    specify IQueue::QueueId::Any as a value, which is equivalent to running
+    ///                    the simpler version of post() above. Valid range is [0, numCoroutineThreads) or
+    ///                    IQueue::QueueId::Any.
+    /// @param[in] isHighPriority If set to true, the sequencer coroutine will be scheduled right 
+    ///                           after the currently executing coroutine on 'queueId'.
+    /// @param[in] opaque pointer to opaque data that is passed to the exception hander (if provided)
+    ///            if an unhandled exception is thrown in func
+    /// @param[in] sequenceKey SequenceKey object that the posted task is associated with
+    /// @param[in] func Callable object.
+    /// @param[in] args Variable list of arguments passed to the callable object.
+    /// @note This function is non-blocking and returns immediately.
+    template <class FUNC, class ... ARGS>
+    void
+    postEx(int queueId, bool isHighPriority, void* opaque, const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
+
+    /// @brief Post a coroutine to run asynchronously.
+    /// @details This method will post the coroutine on any thread available
+    ///          (@see Dispatcher::post for more details).
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    ///              (@see Dispatcher::post for more details).
+    /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
+    /// @param[in] sequenceKeys A collection of sequenceKey objects that the posted task is associated with
+    /// @param[in] func Callable object.
+    /// @param[in] args Variable list of arguments passed to the callable object.
+    /// @note This function is non-blocking and returns immediately.
+    template <class FUNC, class ... ARGS>
+    void
+    post(const std::vector<SequenceKey>& sequenceKeys, FUNC&& func, ARGS&&... args);
+
+    /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    ///              (@see Dispatcher::post for more details).
+    /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
+    /// @param[in] queueId Id of the queue where this coroutine should run. Note that the user 
+    ///                    can specify IQueue::QueueId::Any as a value, which is equivalent to running 
+    ///                    the simpler version of post() above. Valid range is [0, numCoroutineThreads) or 
+    ///                    IQueue::QueueId::Any.
+    /// @param[in] isHighPriority If set to true, the sequencer coroutine will be scheduled right 
+    ///                           after the currently executing coroutine on 'queueId'.
+    /// @param[in] opaque pointer to opaque data that is passed to the exception hander (if provided)
+    ///            if an unhandled exception is thrown in func
+    /// @param[in] sequenceKeys A collection of sequenceKey objects that the posted task is associated with
+    /// @param[in] func Callable object.
+    /// @param[in] args Variable list of arguments passed to the callable object.
+    /// @note This function is non-blocking and returns immediately.
+    template <class FUNC, class ... ARGS>
+    void
+    postEx(int queueId, 
+           bool isHighPriority,
+           void* opaque,
+           const std::vector<SequenceKey>& sequenceKeys, 
+           FUNC&& func, 
+           ARGS&&... args);
+
+    /// @brief Post a coroutine to run asynchronously.
+    /// @details This method will post the coroutine on any thread available 
+    ///          (@see Dispatcher::post for more details). The posted task is assumed to be associated 
+    ///           with the entire universe of sequenceKeys of the SequenceKey type.
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine 
+    ///              (@see Dispatcher::post for more details).
+    /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
+    /// @param[in] func Callable object.
+    /// @param[in] args Variable list of arguments passed to the callable object.
+    /// @remark This function also trims the sequence keys not used by the sequencer anymore
+    /// @note This function is non-blocking and returns immediately.
+    template <class FUNC, class ... ARGS>
+    void
+    postAll(FUNC&& func, ARGS&&... args);
+
+    /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
+    /// @details This method will post the coroutine on any thread available 
+    ///          (@see Dispatcher::post for more details). The posted task is assumed to be associated with 
+    ///           the entire universe of sequenceKeys of the SequenceKey type.
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine 
+    ///              (@see Dispatcher::post for more details).
+    /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
+    /// @param[in] queueId Id of the queue where this coroutine should run. Note that the user 
+    ///                    can specify IQueue::QueueId::Any as a value, which is equivalent to running 
+    ///                    the simpler version of post() above. Valid range is [0, numCoroutineThreads) or 
+    ///                    IQueue::QueueId::Any.
+    /// @param[in] isHighPriority If set to true, the sequencer coroutine will be scheduled right 
+    ///                           after the currently executing coroutine on 'queueId'.
+    /// @param[in] opaque pointer to opaque data that is passed to the exception hander (if provided)
+    ///            if an unhandled exception is thrown in func
+    /// @param[in] func Callable object.
+    /// @param[in] args Variable list of arguments passed to the callable object.
+    /// @remark This function also trims the sequence keys not used by the sequencer anymore
+    /// @note This function is non-blocking and returns immediately.
+    template <class FUNC, class ... ARGS>
+    void
+    postAllEx(int queueId, bool isHighPriority, void* opaque, FUNC&& func, ARGS&&... args);
+
+    /// @brief Trims the sequence keys not used by the sequencer anymore.
+    /// @details It's recommented to call this function periodically to clean up state sequence keys. 
+    /// @remark This call clears all the statistics for trimmed keys. 
+    /// @return The number of sequenceKeys after the trimming.
+    /// @note This function blocks until the trimming job posted to the dispatcher is finished
+    size_t trimSequenceKeys();
+
+    /// @brief Gets the number of tracked sequence keys
+    /// @return sequence key count
+    /// @note This function blocks until the statistics computation job posted to the dispatcher is finished.
+    size_t getSequenceKeyCount();
+
+    /// @brief Gets the sequencer statistics for a sequence key
+    /// @param sequenceKey the key 
+    /// @return the statistics objects for the specified key
+    /// @note This function blocks until the statistics computation job posted to the dispatcher is finished.
+    SequencerKeyStatistics getStatistics(const SequenceKey& sequenceKey);
+
+    /// @brief Gets the sequencer statistics for jobs posted via postAll calls
+    /// @return the statistics objects
+    /// @note This function blocks until the statistics computation job posted to the dispatcher is finished.
+    SequencerKeyStatistics getStatistics();
+
+private:
+    using ContextMap = std::unordered_map<SequenceKey, SequencerKeyData, Hash, KeyEqual, Allocator>;
+    using ExceptionCallback = typename Configuration::ExceptionCallback;
+
+    template <class FUNC, class ... ARGS>
+    static int waitForTwoDependents(CoroContextPtr<int> ctx,
+                                    ICoroContextBasePtr dependent,
+                                    ICoroContextBasePtr universalContext,
+                                    SequencerKeyStatisticsWriter& stats,
+                                    void* opaque, 
+                                    const ExceptionCallback& exceptionCallback,
+                                    FUNC&& func,
+                                    ARGS&&... args);
+    template <class FUNC, class ... ARGS>
+    static int waitForDependents(CoroContextPtr<int> ctx,
+                                 std::vector<std::pair<ICoroContextBasePtr, SequencerKeyStatisticsWriter*>>&& dependents,
+                                 void* opaque,
+                                 const ExceptionCallback& exceptionCallback,
+                                 FUNC&& func,
+                                 ARGS&&... args);
+    template <class FUNC, class ... ARGS>
+    static int singleSequenceKeyTaskScheduler(CoroContextPtr<int> ctx,
+                                              int queueId,
+                                              bool isHighPriority, 
+                                              void* opaque, 
+                                              const ExceptionCallback& exceptionCallback,
+                                              SequenceKey&& sequenceKey,
+                                              ContextMap& contexts,
+                                              SequencerKeyData& universalContext,
+                                              FUNC&& func,
+                                              ARGS&&... args);
+    template <class FUNC, class ... ARGS>
+    static int multiSequenceKeyTaskScheduler(CoroContextPtr<int> ctx,
+                                             int queueId,
+                                             bool isHighPriority, 
+                                             void* opaque, 
+                                             const ExceptionCallback& exceptionCallback,
+                                             std::vector<SequenceKey>&& sequenceKeys,
+                                             ContextMap& contexts,
+                                             SequencerKeyData& universalContext,
+                                             FUNC&& func,
+                                             ARGS&&... args);
+    template <class FUNC, class ... ARGS>
+    static int universalTaskScheduler(CoroContextPtr<int> ctx,
+                                      int queueId,
+                                      bool isHighPriority,
+                                      void* opaque, 
+                                      const ExceptionCallback& exceptionCallback,
+                                      ContextMap& contexts,
+                                      SequencerKeyData& universalContext,
+                                      FUNC&& func,
+                                      ARGS&&... args);
+    template <class FINAL_ACTION, class FUNC, class ... ARGS>
+    static void callPosted(CoroContextPtr<int> ctx, 
+                           const FINAL_ACTION& finalAction,
+                           void* opaque, 
+                           const ExceptionCallback& exceptionCallback,
+                           FUNC&& func, 
+                           ARGS&&... args);
+
+    static bool canTrimContext(const ICoroContextBasePtr& ctx,
+                               const ICoroContextBasePtr& ctxToValidate);
+
+    Dispatcher&              _dispatcher;
+    int                      _controllerQueueId;
+    SequencerKeyData         _universalContext;
+    ContextMap               _contexts;
+    ExceptionCallback        _exceptionCallback;
+};
+
+}}
+
+#include <quantum/util/impl/quantum_sequencer_impl.h>
+
+#endif //QUANTUM_SEQUENCER_H

--- a/src/quantum/util/quantum_sequencer_configuration.h
+++ b/src/quantum/util/quantum_sequencer_configuration.h
@@ -1,0 +1,112 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef QUANTUM_SEQUENCER_CONFIGURATION_H
+#define QUANTUM_SEQUENCER_CONFIGURATION_H
+
+#include <functional>
+#include <memory>
+#include <exception>
+
+namespace Bloomberg {
+namespace quantum {
+
+struct SequencerKeyData;
+
+//==============================================================================================
+//                                      class SequencerConfiguration
+//==============================================================================================
+/// @class SequencerConfiguration.
+/// @brief Implementation of a configuration class for Sequencer
+/// @tparam SequenceKey Type of the key based that sequenced tasks are associated with in Sequencer
+/// @tparam Hash Hash-function used for storing instances of SequncerKey in hash maps in Sequencer
+/// @tparam KeyEqual The equal-function used for storing instances of SequncerKey in hash maps in Sequencer
+/// @tparam Allocator The allocator used for storing instances of SequncerKey in hash maps in Sequencer
+template <class SequenceKey,
+          class Hash = std::hash<SequenceKey>,
+          class KeyEqual = std::equal_to<SequenceKey>,
+          class Allocator = std::allocator<std::pair<const SequenceKey, SequencerKeyData>>>
+class SequencerConfiguration
+{
+public: 
+
+    /// @brief Callback for unhandled exceptions in tasks posted to Sequencer
+    /// @param exception pointer to the thrown exception
+    /// @param opaque opaque data passed when posting a task
+    using ExceptionCallback = std::function<void(std::exception_ptr exception, void* opaque)>;
+
+public:
+    /// @brief Sets the id of the control queue
+    /// @param controlQueueId the queue id
+    void setControlQueueId(int controlQueueId);
+
+    /// @brief Gets the id of the control queue
+    /// @return the queue id
+    int getControlQueueId() const;
+
+    /// @brief Sets the minimal number of buckets to be used for the context hash map
+    /// @param bucketCount the bucket number
+    void setBucketCount(size_t bucketCount);
+
+    /// @brief gets the minimal number of buckets to be used for the context hash map
+    /// @return the bucket number
+    size_t getBucketCount() const;
+
+    /// @brief Sets the hash function to be used for the context hash map
+    /// @param hash the hash function
+    void setHash(const Hash& hash);
+
+    /// @brief Gets the hash function to be used for the context hash map
+    /// @return the hash function
+    const Hash& getHash() const;
+
+    /// @brief Sets the comparison function to be used for all sequenceKey comparisons for the context hash map
+    /// @param keyEqual the comparison function
+    void setKeyEqual(const KeyEqual& keyEqual);
+
+    /// @brief Gets the comparison function to be used for all sequenceKey comparisons for the context hash map
+    /// @return the comparison function
+    const KeyEqual& getKeyEqual() const;
+
+    /// @brief Sets the allocator for all sequenceKey comparisons for the context hash map
+    /// @param allocator the allocator
+    void setAllocator(const Allocator& allocator);
+
+    /// @brief Gets the allocator for all sequenceKey comparisons for the context hash map
+    /// @return the allocator
+    const Allocator& getAllocator() const;
+    
+    /// @brief Sets the exception callback for Scheduler
+    /// @param exceptionCallback the callback to set
+    void setExceptionCallback(const ExceptionCallback& exceptionCallback);
+
+    /// @brief Gets the exception callback for Scheduler
+    /// @return the current callback
+    const ExceptionCallback& getExceptionCallback() const;
+
+private:
+    int _controllerQueueId{0};
+    size_t _bucketCount{0};
+    Hash _hash;
+    KeyEqual _keyEqual;
+    Allocator _allocator;
+    ExceptionCallback _exceptionCallback;
+};
+    
+}}
+
+#include <quantum/util/impl/quantum_sequencer_configuration_impl.h>
+
+#endif //QUANTUM_SEQUENCER_CONFIGURATION_H

--- a/src/quantum/util/quantum_sequencer_key_statistics.h
+++ b/src/quantum/util/quantum_sequencer_key_statistics.h
@@ -1,0 +1,89 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef QUANTUM_SEQUENCER_KEY_STATISTICS_H
+#define QUANTUM_SEQUENCER_KEY_STATISTICS_H
+
+#include <vector>
+#include <tuple>
+#include <atomic>
+
+namespace Bloomberg {
+namespace quantum {
+
+//==============================================================================================
+//                                      class SequencerKeyStatistics
+//==============================================================================================
+/// @class SequencerKeyStatistics.
+/// @brief Implementation of a statistics collection for a sequence key in Sequencer
+class SequencerKeyStatistics
+{
+public:
+    /// @brief Constructor.
+    SequencerKeyStatistics() = default;
+
+    /// @brief Constructor.
+    SequencerKeyStatistics(const SequencerKeyStatistics& that);
+
+    /// @brief Constructor.
+    SequencerKeyStatistics(SequencerKeyStatistics&& that);
+
+    /// @brief Assignment operator.
+    SequencerKeyStatistics& operator = (const SequencerKeyStatistics& that);
+
+    /// @brief Assignment operator.
+    SequencerKeyStatistics& operator = (SequencerKeyStatistics&& that);
+
+    /// @brief Gets the total number of tasks associated with the key that have been posted to the Sequencer
+    ///        since the sequencer started tracking the key
+    /// @return the number of tasks
+    size_t getPostedTaskCount() const;
+
+    /// @brief Gets the total number of pending tasks associated with the key
+    /// @remark A task is pending if the dispatcher has not started it yet
+    /// @return the number of tasks
+    size_t getPendingTaskCount() const;
+
+protected:
+    /// @brief Number of posted tasks associated with the sequence key
+    size_t _postedTaskCount{0};
+    /// @brief Number of pending tasks associated with the sequence key
+    std::atomic<size_t> _pendingTaskCount{0};
+};
+
+//==============================================================================================
+//                                      class SequencerKeyStatisticsWriter
+//==============================================================================================
+/// @class SequencerKeyStatistics.
+/// @brief Implementation of a writer for the SequencerKeyStatistics
+class SequencerKeyStatisticsWriter: public SequencerKeyStatistics
+{
+public:
+    /// @brief Increments the total number of tasks associated with the key that have been posted to the Sequencer
+    ///        since the sequencer started tracking the key
+    void incrementPostedTaskCount();
+
+    /// @brief Increments the total number of pending tasks associated with the key
+    void incrementPendingTaskCount();
+
+    /// @brief Increments the total number of pending tasks associated with the key
+    void decrementPendingTaskCount();
+};
+
+}}
+
+#include <quantum/util/impl/quantum_sequencer_key_statistics_impl.h>
+
+#endif //QUANTUM_SEQUENCER_KEY_STATISTICS_H

--- a/tests/sequencer_tests.cpp
+++ b/tests/sequencer_tests.cpp
@@ -1,0 +1,512 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#include <quantum/quantum.h>
+#include <gtest/gtest.h>
+#include <quantum_fixture.h>
+
+using namespace quantum;
+
+// Utility with common functionality for the sequencer related tests
+class SequencerTestData
+{
+public: // types
+    using SequenceKey = int;
+    using TaskId = int;
+    using TaskSequencer = Sequencer<SequenceKey>;
+    struct TaskResult
+    {
+        /// Task start time
+        std::chrono::system_clock::time_point startTime;
+        /// Task end time
+        std::chrono::system_clock::time_point endTime;
+    };
+    using TaskResultMap = std::unordered_map<TaskId, TaskResult>;
+    using SequenceKeyMap = std::unordered_map<SequenceKey, std::vector<TaskId>>;
+
+    /**
+     * @Brief checks if a task was started before another task finished
+     * @param befre
+     */
+    void ensureOrder(TaskId beforeTaskId, TaskId afterTaskId)
+    {        
+        TaskResultMap::const_iterator beforeTaskIt = _results.find(beforeTaskId);
+        ASSERT_NE(beforeTaskIt, _results.end());
+        TaskResultMap::const_iterator afterTaskIt = _results.find(afterTaskId);
+        ASSERT_NE(afterTaskIt, _results.end());
+        if (beforeTaskIt == _results.end() || afterTaskIt == _results.end())
+        {
+            return;
+        }
+        EXPECT_LE(beforeTaskIt->second.endTime, afterTaskIt->second.startTime);
+    }
+    
+    std::function<int(CoroContext<int>::Ptr)> makeTask(TaskId taskId)
+    {
+        return [this, taskId](CoroContext<int>::Ptr ctx)
+        {
+            return taskFunc(ctx, taskId, nullptr, "");
+        };
+    }
+
+    std::function<int(CoroContext<int>::Ptr)> makeTaskWithBlock(TaskId taskId, std::atomic<bool>* blockFlag)
+    {
+        return [this, taskId, blockFlag](CoroContext<int>::Ptr ctx)
+        {
+            return taskFunc(ctx, taskId, blockFlag, "");
+        };
+    }
+
+    std::function<int(CoroContext<int>::Ptr)> makeTaskWithException(TaskId taskId, std::string error)
+    {
+        return [this, taskId, error](CoroContext<int>::Ptr ctx)
+        {
+            return taskFunc(ctx, taskId, nullptr, error);
+        };
+    }
+
+    TaskResultMap& results()
+    {
+        return _results;
+    }
+    
+    void sleep(int periodCount = 1)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(periodCount*20));
+    }
+    
+private: // methods
+
+    int taskFunc(CoroContext<int>::Ptr ctx, TaskId id, std::atomic<bool> * blockFlag, std::string error)
+    {
+        std::chrono::system_clock::time_point startTime = std::chrono::system_clock::now();
+        do{
+            sleep();
+            if (not error.empty())
+                throw std::runtime_error(error);
+        }
+        while(blockFlag and *blockFlag);
+        std::chrono::system_clock::time_point endTime = std::chrono::system_clock::now();
+
+        // update the task map with the time stats
+        std::unique_lock<std::mutex> lock(_resultMutex);
+        
+        _results[id].startTime = startTime;
+        _results[id].endTime = endTime;
+        return ctx->set(0);
+    }
+
+private: // members
+
+    /// task results
+    TaskResultMap _results;
+    // mutex for _results accessing
+    std::mutex _resultMutex;
+};
+
+TEST(Sequencer, BasicTaskOrder)
+{
+    using namespace Bloomberg::quantum;
+
+    const int taskCount = 100;
+    const int sequenceKeyCount = 3;
+    SequencerTestData testData;
+    SequencerTestData::SequenceKeyMap sequenceKeys;
+    
+    SequencerTestData::TaskSequencer sequencer(DispatcherSingleton::instance());
+
+    // enqueue the tasks with
+    for(SequencerTestData::TaskId id = 0; id < taskCount; ++id) 
+    {
+        SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
+        // save the taskid for this sequenceKey
+        sequenceKeys[sequenceKey].push_back(id);
+        sequencer.post(sequenceKey, testData.makeTask(id));
+    }
+    DispatcherSingleton::instance().drain();
+
+    EXPECT_EQ(testData.results().size(), (size_t)taskCount);
+
+    // the tasks must be ordered within the same sequenceKey
+    for(auto sequenceKeyData : sequenceKeys) 
+    {
+        for(size_t i = 1; i < sequenceKeyData.second.size(); ++i) 
+        {
+            testData.ensureOrder(sequenceKeyData.second[i-1], sequenceKeyData.second[i]);
+        }
+    }
+}
+
+TEST(Sequencer, TrimKeys)
+{
+    using namespace Bloomberg::quantum;
+
+    const int taskCount = 100;
+    const int sequenceKeyCount = 3;
+    SequencerTestData testData;
+    
+    SequencerTestData::TaskSequencer sequencer(DispatcherSingleton::instance());
+
+    // enqueue the tasks with    
+    for(SequencerTestData::TaskId id = 0; id < taskCount; ++id)
+    {
+        SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
+        sequencer.post(sequenceKey, testData.makeTask(id));
+    }
+    DispatcherSingleton::instance().drain();
+
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), (size_t)sequenceKeyCount);
+    EXPECT_EQ(sequencer.trimSequenceKeys(), 0u);
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), 0u);
+}
+
+TEST(Sequencer, ExceptionHandler)
+{
+    using namespace Bloomberg::quantum;
+
+    const int taskCount = 100;
+    const int sequenceKeyCount = 3;
+    const int exceptionFrequency = 14;
+    SequencerTestData testData;
+    std::vector<SequencerTestData::TaskId> sequenceKeys(taskCount);
+
+    // generate the sequence of tasks for passing as opaque
+    int generateTaskId = 0;
+    std::generate(sequenceKeys.begin(), 
+                  sequenceKeys.end(), 
+                  [&generateTaskId]() { return generateTaskId++; });
+    
+    const std::string errorText = "Error";
+    // the callback will check that exceptions are generated as expected
+    unsigned int exceptionCallbackCallCount = 0;
+    auto exceptionCallback = [&exceptionCallbackCallCount, &errorText](std::exception_ptr exception, void* opaque)
+    {
+        ASSERT_NE(exception, nullptr);
+        try
+        {
+            if (exception) 
+            {
+                std::rethrow_exception(exception);
+            }
+            // the exception above must be thrown
+            ASSERT_TRUE(false);
+        }
+        catch(const std::exception& e)
+        {
+            ++exceptionCallbackCallCount;
+
+            EXPECT_EQ(e.what(), errorText);
+            ASSERT_NE(opaque, nullptr);
+            SequencerTestData::TaskId taskId = *static_cast<SequencerTestData::TaskId*>(opaque);
+            EXPECT_EQ(taskId % exceptionFrequency, 0);
+        }
+        catch(...)
+        {
+            ASSERT_TRUE(false);
+        }
+    };
+    
+    SequencerConfiguration<SequencerTestData::SequenceKey> config;
+    config.setExceptionCallback(exceptionCallback);
+    SequencerTestData::TaskSequencer sequencer(DispatcherSingleton::instance(), config);
+
+    unsigned int generatedExceptionCount = 0;
+    for(SequencerTestData::TaskId id = 0; id < taskCount; ++id)
+    {
+        SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
+        if (id % exceptionFrequency == 0)
+        {
+            // post with generating exception
+            sequencer.postEx((int)IQueue::QueueId::Any, false, &sequenceKeys[id], sequenceKey, testData.makeTaskWithException(id, errorText));
+            ++generatedExceptionCount;
+        }
+        else
+        {
+            // post with no exception generation
+            sequencer.postEx((int)IQueue::QueueId::Any, false, &sequenceKeys[id], sequenceKey, testData.makeTask(id));
+        }
+    }
+    DispatcherSingleton::instance().drain();
+
+    EXPECT_EQ(generatedExceptionCount, exceptionCallbackCallCount);
+}
+
+TEST(Sequencer, SequenceKeyStats)
+{
+    using namespace Bloomberg::quantum;
+
+    const int taskCount = 50;
+    const int sequenceKeyCount = 3;
+    const int universalTaskFrequency = 11; // every 11th task is universal
+    SequencerTestData testData;
+    std::atomic<bool> blockFlag(true);
+    
+    SequencerTestData::TaskSequencer sequencer(DispatcherSingleton::instance());
+
+    // enqueue the first half
+    for(SequencerTestData::TaskId id = 0; id < taskCount / 2; ++id) 
+    {
+        if ( id % universalTaskFrequency == 0 ) 
+        {
+            sequencer.postAll(testData.makeTaskWithBlock(id, &blockFlag));
+        }
+        else
+        {
+            SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
+            sequencer.post(sequenceKey, testData.makeTaskWithBlock(id, &blockFlag));
+        }
+    }
+
+    // sleep for a while to make sure alll the tasks are scheduled
+    testData.sleep(sequenceKeyCount);
+
+    // make sure all the enqueued tasks are pending
+    size_t postedCount = 0;
+    size_t pendingCount = 0;
+    for(int key = 0; key < sequenceKeyCount; ++key)
+    {
+        auto stats = sequencer.getStatistics(key);
+        postedCount += stats.getPostedTaskCount();
+        pendingCount += stats.getPendingTaskCount();
+    }
+    auto universalStats = sequencer.getStatistics();
+    postedCount += universalStats.getPostedTaskCount();
+    pendingCount += universalStats.getPendingTaskCount();
+
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), sequenceKeyCount);
+    EXPECT_EQ(postedCount, (unsigned int)taskCount / 2);
+    EXPECT_EQ(pendingCount, (unsigned int)taskCount / 2);
+    
+    // release the tasks 
+    blockFlag = false;
+
+    // enqueue the second half
+    for(SequencerTestData::TaskId id = taskCount / 2; id < taskCount; ++id) 
+    {
+        if ( id % universalTaskFrequency == 0 ) 
+        {
+            sequencer.postAll(testData.makeTaskWithBlock(id, &blockFlag));
+        }
+        else
+        {
+            SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
+            sequencer.post(sequenceKey, testData.makeTaskWithBlock(id, &blockFlag));
+        }
+    }
+
+    DispatcherSingleton::instance().drain();
+
+    // check the final stats
+    postedCount = 0;
+    pendingCount = 0;
+    for(int key = 0; key < sequenceKeyCount; ++key)
+    {
+        auto stats = sequencer.getStatistics(key);
+        postedCount += stats.getPostedTaskCount();
+        pendingCount += stats.getPendingTaskCount();
+    }
+    auto universalStatsAfter = sequencer.getStatistics();
+    postedCount += universalStatsAfter.getPostedTaskCount();
+    pendingCount += universalStatsAfter.getPendingTaskCount();
+
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), sequenceKeyCount);
+    EXPECT_EQ(postedCount, (unsigned int)taskCount);
+    EXPECT_EQ(pendingCount, 0u);
+}
+
+TEST(Sequencer, TaskOrderWithUniversal)
+{
+    using namespace Bloomberg::quantum;
+
+    const int taskCount = 50;
+    const int sequenceKeyCount = 3;
+    const int universalTaskFrequency = 11; // every 11th task is universal
+    SequencerTestData testData;
+    SequencerTestData::SequenceKeyMap sequenceKeys;
+    std::vector<SequencerTestData::TaskId> universal;
+    
+    SequencerTestData::TaskSequencer sequencer(DispatcherSingleton::instance());
+    
+    for(SequencerTestData::TaskId id = 0; id < taskCount; ++id) 
+    {
+        if ( id % universalTaskFrequency == 0 ) 
+        {
+            // save the taskid as universal
+            universal.push_back(id);
+            sequencer.postAll(testData.makeTask(id));
+        }
+        else 
+        {
+            SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
+            // save the taskid for this sequenceKey
+            sequenceKeys[sequenceKey].push_back(id);
+            sequencer.post(sequenceKey, testData.makeTask(id));
+        }
+    }
+    DispatcherSingleton::instance().drain();
+
+    EXPECT_EQ(testData.results().size(), (size_t)taskCount);
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), sequenceKeyCount);
+
+    // the tasks must be ordered within the same sequenceKey
+    for(auto sequenceKeyData : sequenceKeys) 
+    {
+        for(size_t i = 1; i < sequenceKeyData.second.size(); ++i) 
+        {
+            testData.ensureOrder(sequenceKeyData.second[i-1], sequenceKeyData.second[i]);
+        }
+    }
+    // all tasks enqueued before a universal task must be finished before it starts
+    for (auto universalTaskId : universal) 
+    {
+        for(SequencerTestData::TaskId taskId = 0; taskId < universalTaskId; ++taskId) 
+        {
+            testData.ensureOrder(taskId, universalTaskId);
+        }
+    }    
+    // all tasks enqueued after a universal task must be started after it finishes
+    for (auto universalTaskId : universal) 
+    {
+        for(SequencerTestData::TaskId taskId = universalTaskId + 1; taskId < taskCount; ++taskId) 
+        {
+            testData.ensureOrder(universalTaskId, taskId);
+        }
+    }    
+}
+
+TEST(Sequencer, MultiSequenceKeyTasks)
+{
+    using namespace Bloomberg::quantum;
+
+    const int sequenceKeyCount = 7;
+    const int taskCount = (2 << (sequenceKeyCount - 1)) - 1;
+    SequencerTestData testData;
+
+    // constructs a sequence key collection from the bitmap of an unsigned it, 
+    // e.g. for the taskId = 5, the returned collection will be {0, 2}
+    auto getBitVector = [](unsigned int value)->std::vector<SequencerTestData::SequenceKey>
+    {
+        std::vector<SequencerTestData::SequenceKey> result;
+        int bit = 0;
+        for(; value; ++bit, value = value >> 1) 
+        {
+            if ( value % 2 ) 
+            {
+                result.push_back(bit);
+            }
+        }
+        return result;
+    };
+    
+    SequencerTestData::TaskSequencer sequencer(DispatcherSingleton::instance());    
+    for(SequencerTestData::TaskId id = 1; id <= taskCount; ++id) 
+    {
+        std::vector<SequencerTestData::SequenceKey> sequenceKeys = getBitVector(id);
+        // save the taskid for this sequenceKey
+        sequencer.post(sequenceKeys, testData.makeTask(id));
+    }
+    DispatcherSingleton::instance().drain();
+
+    EXPECT_EQ(testData.results().size(), (size_t)taskCount);
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), sequenceKeyCount);
+
+    // the tasks must be ordered within the sequenceKey set intersection
+    for(SequencerTestData::TaskId id = 1; id <= taskCount; ++id) 
+    {
+        for(SequencerTestData::TaskId refId = 1; refId <= taskCount; ++refId) 
+        {
+            if ( id != refId and id & refId ) 
+            {
+                if ( refId < id ) 
+                {
+                    testData.ensureOrder(refId, id);
+                } 
+                else 
+                {
+                    testData.ensureOrder(id, refId);
+                }
+            }
+        }
+    }
+}
+
+TEST(Sequencer, CustomHashFunction)
+{
+    using namespace Bloomberg::quantum;
+
+    const int taskCount = 100;
+    const int fullSequenceKeyCount = 20;
+    const int restrictedSequenceKeyCount = 3;
+    SequencerTestData testData;
+    SequencerTestData::SequenceKeyMap sequenceKeys;
+
+    // our custom hash value will be restricted to [0, restrictedSequenceKeyCount-1]
+    using Hasher = std::function<size_t(SequencerTestData::SequenceKey sequenceKeyId)>;
+    Hasher customHasher = [restrictedSequenceKeyCount](SequencerTestData::SequenceKey sequenceKeyId)->size_t 
+    {
+        return std::hash<SequencerTestData::SequenceKey>()(sequenceKeyId % restrictedSequenceKeyCount);
+    };
+
+    // our custom equal operator will compare the hash values of sequenceKeys
+    // this effectively means that the number of sequenceKeys is reduced to
+    // restrictedSequenceKeyCount. So we get a lower memory consumption due to the 
+    // bound size of the hash table in Sequencer and hence need not to call
+    // trimSequenceKeys from time to time. The price for this is a reduced parallelism:
+    // instead of running at most fullSequenceKeyCount tasks in parallel, we can now run at most
+    // restrictedSequenceKeyCount
+
+    using KeyEqual = std::function<bool(SequencerTestData::SequenceKey sequenceKeyId0, SequencerTestData::SequenceKey sequenceKeyId1)>;
+    const KeyEqual customEqual = [customHasher](SequencerTestData::SequenceKey sequenceKeyId0, SequencerTestData::SequenceKey sequenceKeyId1)->bool 
+    {
+        return customHasher(sequenceKeyId0) == customHasher(sequenceKeyId1);
+    };
+
+    SequencerConfiguration<SequencerTestData::SequenceKey, Hasher, KeyEqual> config;
+    config.setControlQueueId(0);
+    config.setBucketCount(0);
+    config.setHash(customHasher);
+    config.setKeyEqual(customEqual);
+    
+    Sequencer<SequencerTestData::SequenceKey, Hasher, KeyEqual>
+        sequencer(DispatcherSingleton::instance(), config);
+    
+    for(SequencerTestData::TaskId id = 0; id < taskCount; ++id) 
+    {
+        SequencerTestData::SequenceKey sequenceKey = id % fullSequenceKeyCount;
+        // save the taskid for this sequenceKey
+        sequenceKeys[sequenceKey].push_back(id);
+        // post the task with the real sequenceKey id
+        sequencer.post(std::move(sequenceKey), testData.makeTask(id));
+    }
+    DispatcherSingleton::instance().drain();
+
+    EXPECT_EQ(testData.results().size(), (size_t)taskCount);
+    EXPECT_EQ(sequencer.getSequenceKeyCount(), restrictedSequenceKeyCount);
+
+    // the tasks must be ordered within the same sequenceKey
+    for(auto sequenceKeyData : sequenceKeys) 
+    {
+        for(size_t i = 1; i < sequenceKeyData.second.size(); ++i) 
+        {
+            testData.ensureOrder(sequenceKeyData.second[i-1], sequenceKeyData.second[i]);
+        }
+    }
+}
+
+//This test **must** come last to make Valgrind happy.
+TEST(Sequencer, DeleteDispatcherInstance)
+{
+    DispatcherSingleton::deleteInstance();
+}


### PR DESCRIPTION
Signed-off-by: Denis Mindolin <dmindolin1@bloomberg.net>
Implementation of a simple task Sequencer based on sequence keys. Each posted task can be associated with one more more sequence keys. The Sequencer guarantees that given two tasks T1 and T2 associated with sets of keys S1 and S2 such that S1 and S2 have common keys and T1 was posted before T2, then T2 will be started only after T1 is finished. 