### PR TITLE
Refactored postEx argument positions 

### DIFF
--- a/src/quantum/util/impl/quantum_sequencer_impl.h
+++ b/src/quantum/util/impl/quantum_sequencer_impl.h
@@ -52,7 +52,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
 {
     _dispatcher.post<int>(_controllerQueueId,
                           false,
-                          &singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
                           (int)IQueue::QueueId::Any,
                           false,
                           nullptr,
@@ -67,10 +67,10 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postEx(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+    void* opaque,
     int queueId,
     bool isHighPriority,
-    void* opaque,
     const SequenceKey& sequenceKey,
     FUNC&& func,
     ARGS&&... args)
@@ -82,7 +82,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postEx(
 
     _dispatcher.post<int>(_controllerQueueId,
                           false,
-                          &singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
                           queueId,
                           isHighPriority,
                           std::move(opaque),
@@ -104,7 +104,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
 {
     _dispatcher.post<int>(_controllerQueueId,
                           false,
-                          &multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
                           (int)IQueue::QueueId::Any,
                           false,
                           nullptr,
@@ -119,10 +119,10 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postEx(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+    void* opaque,
     int queueId,
     bool isHighPriority,
-    void* opaque,
     const std::vector<SequenceKey>& sequenceKeys,
     FUNC&& func,
     ARGS&&... args)
@@ -133,7 +133,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postEx(
     }
     _dispatcher.post<int>(_controllerQueueId,
                           false,
-                          &multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                          multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
                           queueId,
                           isHighPriority,
                           std::move(opaque),
@@ -152,7 +152,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(FUNC&& func, ARGS&&..
 {
     _dispatcher.post<int>(_controllerQueueId,
                           false,
-                          &universalTaskScheduler<FUNC, ARGS...>,
+                          universalTaskScheduler<FUNC, ARGS...>,
                           (int)IQueue::QueueId::Any,
                           false,
                           nullptr,
@@ -166,10 +166,10 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(FUNC&& func, ARGS&&..
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAllEx(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(
+    void* opaque,
     int queueId,
     bool isHighPriority,
-    void* opaque,
     FUNC&& func,
     ARGS&&... args)
 {
@@ -179,7 +179,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAllEx(
     }
     _dispatcher.post<int>(_controllerQueueId,
                           false,
-                          &universalTaskScheduler<FUNC, ARGS...>,
+                          universalTaskScheduler<FUNC, ARGS...>,
                           queueId,
                           isHighPriority,
                           std::move(opaque),
@@ -257,8 +257,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::waitForTwoDependents(
     ICoroContextBasePtr universalContext,
     SequenceKeyStatisticsWriter& stats,
     void* opaque,
-    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
-        exceptionCallback,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& exceptionCallback,
     FUNC&& func,
     ARGS&&... args)
 {
@@ -280,7 +279,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::waitForTwoDependents(
     };
     callPosted(ctx, 
                updateStatsAction, 
-               opaque, 
+               opaque,
                exceptionCallback, 
                std::forward<FUNC>(func), 
                std::forward<ARGS>(args)...);
@@ -294,8 +293,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::waitForDependents(
     CoroContextPtr<int> ctx,
     std::vector<std::pair<ICoroContextBasePtr, SequenceKeyStatisticsWriter*>>&& dependents,
     void* opaque,
-    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
-        exceptionCallback,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& exceptionCallback,
     FUNC&& func,
     ARGS&&... args)
 {
@@ -322,7 +320,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::waitForDependents(
     };
     callPosted(ctx, 
                updateStatsAction, 
-               opaque, 
+               opaque,
                exceptionCallback, 
                std::forward<FUNC>(func), 
                std::forward<ARGS>(args)...);
@@ -337,8 +335,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::singleSequenceKeyTaskSchedule
     int queueId,
     bool isHighPriority,
     void* opaque,
-    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
-        exceptionCallback,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& exceptionCallback,
     SequenceKey&& sequenceKey,
     ContextMap& contexts,
     SequenceKeyData& universalContext,
@@ -357,7 +354,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::singleSequenceKeyTaskSchedule
     // save the context as the last for this sequenceKey
     contextIt->second.context = ctx->post<int>(queueId,
                                                isHighPriority,
-                                               &waitForTwoDependents<FUNC, ARGS...>,
+                                               waitForTwoDependents<FUNC, ARGS...>,
                                                ICoroContextBasePtr(contextIt->second.context),
                                                ICoroContextBasePtr(universalContext.context),
                                                contextIt->second.stats,
@@ -376,8 +373,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::multiSequenceKeyTaskScheduler
     int queueId,
     bool isHighPriority,
     void* opaque,
-    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
-        exceptionCallback,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& exceptionCallback,
     std::vector<SequenceKey>&& sequenceKeys,
     ContextMap& contexts,
     SequenceKeyData& universalContext,
@@ -393,7 +389,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::multiSequenceKeyTaskScheduler
         auto taskIt = contexts.find(sequenceKey);
         if (taskIt != contexts.end())
         {
-            // update the depedent stats only
+            // update the dependent stats only
             taskIt->second.stats.incrementPostedTaskCount();
             taskIt->second.stats.incrementPendingTaskCount();
             // pass the pointer to the stats to the wait function so that it updates them too
@@ -402,7 +398,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::multiSequenceKeyTaskScheduler
     }
     ICoroContextBasePtr newCtx = ctx->post<int>(queueId,
                                                 isHighPriority,
-                                                &waitForDependents<FUNC, ARGS...>,
+                                                waitForDependents<FUNC, ARGS...>,
                                                 std::move(dependents),
                                                 std::move(opaque),
                                                 exceptionCallback,
@@ -424,8 +420,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::universalTaskScheduler(
     int queueId,
     bool isHighPriority,
     void* opaque,
-    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
-        exceptionCallback,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& exceptionCallback,
     ContextMap& contexts,
     SequenceKeyData& universalContext,
     FUNC&& func,
@@ -471,8 +466,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::callPosted(
     CoroContextPtr<int> ctx,
     const FINAL_ACTION& finalAction,
     void* opaque,
-    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback&
-        exceptionCallback,
+    const typename Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::ExceptionCallback& exceptionCallback,
     FUNC&& func,
     ARGS&&... args)
 {

--- a/src/quantum/util/quantum_sequencer.h
+++ b/src/quantum/util/quantum_sequencer.h
@@ -83,7 +83,7 @@ public:
     /// @note This function is non-blocking and returns immediately.
     template <class FUNC, class ... ARGS>
     void
-    postEx(int queueId, bool isHighPriority, void* opaque, const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
+    post(void* opaque, int queueId, bool isHighPriority, const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
 
     /// @brief Post a coroutine to run asynchronously.
     /// @details This method will post the coroutine on any thread available
@@ -117,12 +117,12 @@ public:
     /// @note This function is non-blocking and returns immediately.
     template <class FUNC, class ... ARGS>
     void
-    postEx(int queueId, 
-           bool isHighPriority,
-           void* opaque,
-           const std::vector<SequenceKey>& sequenceKeys, 
-           FUNC&& func, 
-           ARGS&&... args);
+    post(void* opaque,
+         int queueId,
+         bool isHighPriority,
+         const std::vector<SequenceKey>& sequenceKeys,
+         FUNC&& func,
+         ARGS&&... args);
 
     /// @brief Post a coroutine to run asynchronously.
     /// @details This method will post the coroutine on any thread available 
@@ -160,7 +160,7 @@ public:
     /// @note This function is non-blocking and returns immediately.
     template <class FUNC, class ... ARGS>
     void
-    postAllEx(int queueId, bool isHighPriority, void* opaque, FUNC&& func, ARGS&&... args);
+    postAll(void* opaque, int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
 
     /// @brief Trims the sequence keys not used by the sequencer anymore.
     /// @details It's recommented to call this function periodically to clean up state sequence keys. 
@@ -194,7 +194,7 @@ private:
                                     ICoroContextBasePtr dependent,
                                     ICoroContextBasePtr universalContext,
                                     SequenceKeyStatisticsWriter& stats,
-                                    void* opaque, 
+                                    void* opaque,
                                     const ExceptionCallback& exceptionCallback,
                                     FUNC&& func,
                                     ARGS&&... args);
@@ -209,7 +209,7 @@ private:
     static int singleSequenceKeyTaskScheduler(CoroContextPtr<int> ctx,
                                               int queueId,
                                               bool isHighPriority, 
-                                              void* opaque, 
+                                              void* opaque,
                                               const ExceptionCallback& exceptionCallback,
                                               SequenceKey&& sequenceKey,
                                               ContextMap& contexts,
@@ -220,7 +220,7 @@ private:
     static int multiSequenceKeyTaskScheduler(CoroContextPtr<int> ctx,
                                              int queueId,
                                              bool isHighPriority, 
-                                             void* opaque, 
+                                             void* opaque,
                                              const ExceptionCallback& exceptionCallback,
                                              std::vector<SequenceKey>&& sequenceKeys,
                                              ContextMap& contexts,
@@ -231,7 +231,7 @@ private:
     static int universalTaskScheduler(CoroContextPtr<int> ctx,
                                       int queueId,
                                       bool isHighPriority,
-                                      void* opaque, 
+                                      void* opaque,
                                       const ExceptionCallback& exceptionCallback,
                                       ContextMap& contexts,
                                       SequenceKeyData& universalContext,
@@ -240,7 +240,7 @@ private:
     template <class FINAL_ACTION, class FUNC, class ... ARGS>
     static void callPosted(CoroContextPtr<int> ctx, 
                            const FINAL_ACTION& finalAction,
-                           void* opaque, 
+                           void* opaque,
                            const ExceptionCallback& exceptionCallback,
                            FUNC&& func, 
                            ARGS&&... args);
@@ -250,7 +250,7 @@ private:
 
     Dispatcher&              _dispatcher;
     int                      _controllerQueueId;
-    SequenceKeyData         _universalContext;
+    SequenceKeyData          _universalContext;
     ContextMap               _contexts;
     ExceptionCallback        _exceptionCallback;
 };

--- a/tests/sequencer_tests.cpp
+++ b/tests/sequencer_tests.cpp
@@ -229,13 +229,13 @@ TEST(Sequencer, ExceptionHandler)
         if (id % exceptionFrequency == 0)
         {
             // post with generating exception
-            sequencer.postEx((int)IQueue::QueueId::Any, false, &sequenceKeys[id], sequenceKey, testData.makeTaskWithException(id, errorText));
+            sequencer.post(&sequenceKeys[id], (int)IQueue::QueueId::Any, false, sequenceKey, testData.makeTaskWithException(id, errorText));
             ++generatedExceptionCount;
         }
         else
         {
             // post with no exception generation
-            sequencer.postEx((int)IQueue::QueueId::Any, false, &sequenceKeys[id], sequenceKey, testData.makeTask(id));
+            sequencer.post(&sequenceKeys[id], (int)IQueue::QueueId::Any, false, sequenceKey, testData.makeTask(id));
         }
     }
     DispatcherSingleton::instance().drain();
@@ -498,7 +498,7 @@ TEST(Sequencer, CustomHashFunction)
     // the tasks must be ordered within the same sequenceKey
     for(auto sequenceKeyData : sequenceKeys) 
     {
-        for(size_t i = 1; i < sequenceKeyData.second.size(); ++i) 
+        for(size_t i = 1; i < sequenceKeyData.second.size(); ++i)
         {
             testData.ensureOrder(sequenceKeyData.second[i-1], sequenceKeyData.second[i]);
         }


### PR DESCRIPTION
Refactored `postEx` argument positions to avoid having two overloaded function names. This was done by moving the `void* opaque` to the front of the argument list. Because of this, the _Ex_ functions can now be renamed `post` just like the other ones. The original issue arose from the clash in type when `sequenceKey` was an `int`, therefore ADL would resolve it with the `queueId` parameter which was wrong.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>