### PR TITLE
Changes to reduce CPU overload when a coroutine sleeps or is blocked.

### DIFF
--- a/src/quantum/impl/quantum_io_queue_impl.h
+++ b/src/quantum/impl/quantum_io_queue_impl.h
@@ -342,7 +342,10 @@ void IoQueue::terminate()
 {
     if (!_terminated.test_and_set() && _sharedIoQueues)
     {
-        _isInterrupted = true;
+        {
+            std::unique_lock<std::mutex> lock(_notEmptyMutex);
+            _isInterrupted = true;
+        }
         if (!_loadBalanceSharedIoQueues) {
             _notEmptyCond.notify_all();
         }

--- a/src/quantum/impl/quantum_io_task_impl.h
+++ b/src/quantum/impl/quantum_io_task_impl.h
@@ -110,6 +110,12 @@ bool IoTask::isBlocked() const
 }
 
 inline
+bool IoTask::isSleeping(bool)
+{
+    return false;
+}
+
+inline
 bool IoTask::isHighPriority() const
 {
     return _isHighPriority;

--- a/src/quantum/impl/quantum_task_impl.h
+++ b/src/quantum/impl/quantum_task_impl.h
@@ -151,7 +151,13 @@ ITaskContinuation::Ptr Task::getErrorHandlerOrFinalTask()
 inline
 bool Task::isBlocked() const
 {
-    return _ctx ? _ctx->isBlocked() : false; //context is waiting on some signal
+    return _ctx ? _ctx->isBlocked() : false; //coroutine is waiting on some signal
+}
+
+inline
+bool Task::isSleeping(bool updateTimer)
+{
+    return _ctx ? _ctx->isSleeping(updateTimer) : false; //coroutine is sleeping
 }
 
 inline

--- a/src/quantum/interface/quantum_icoro_sync.h
+++ b/src/quantum/interface/quantum_icoro_sync.h
@@ -54,10 +54,13 @@ struct ICoroSync
     /// @return An atomic integer used to synchronize with other primitive types.
     virtual std::atomic_int& signal() = 0;
     
-    /// @brief Sleeps the coroutine associated with this context for 'timeMs' milliseconds.
-    /// @param[in] timeMs Time to sleep.
-    /// @note This method repeatedly yields the coroutine until the timer has expired.
-    virtual void sleep(std::chrono::milliseconds timeMs) = 0;
+    /// @brief Sleeps the coroutine associated with this context for *at least* 'timeMs' milliseconds or
+    ///        'timeUs' microseconds depending on the overload chosen.
+    /// @param[in] timeMs/timeUs Time to sleep.
+    /// @note This method yields the coroutine until the timer has expired. Depending on the
+    ///       coroutine load on the particular running thread, this method may sleep longer.
+    virtual void sleep(const std::chrono::milliseconds& timeMs) = 0;
+    virtual void sleep(const std::chrono::microseconds& timeUs) = 0;
 };
 
 using ICoroSyncPtr = ICoroSync::Ptr;

--- a/src/quantum/interface/quantum_itask.h
+++ b/src/quantum/interface/quantum_itask.h
@@ -59,6 +59,8 @@ struct ITask : public ITerminate
     
     virtual bool isBlocked() const = 0;
     
+    virtual bool isSleeping(bool updateTimer = false) = 0;
+    
     virtual bool isHighPriority() const = 0;
 };
 

--- a/src/quantum/interface/quantum_itask_accessor.h
+++ b/src/quantum/interface/quantum_itask_accessor.h
@@ -36,7 +36,9 @@ struct ITaskAccessor : public ITerminate
     
     virtual ITask::Ptr getTask() const = 0;
     
-    virtual bool isBlocked() = 0;
+    virtual bool isBlocked() const = 0;
+    
+    virtual bool isSleeping(bool updateTimer = false) = 0;
 };
 
 using ITaskAccessorPtr = ITaskAccessor::Ptr;

--- a/src/quantum/quantum_context.h
+++ b/src/quantum/quantum_context.h
@@ -63,7 +63,8 @@ public:
     //===================================
     void setTask(ITask::Ptr task) final;
     ITask::Ptr getTask() const final;
-    bool isBlocked() final;
+    bool isBlocked() const final;
+    bool isSleeping(bool updateTimer = false) final;
 
     //===================================
     //         ICONTEXTBASE
@@ -109,7 +110,8 @@ public:
     Traits::Yield& getYieldHandle() final;
     void yield() final;
     std::atomic_int& signal() final;
-    void sleep(std::chrono::milliseconds timeMs) final;
+    void sleep(const std::chrono::milliseconds& timeMs) final;
+    void sleep(const std::chrono::microseconds& timeUs) final;
     
     //===================================
     //   NON-VIRTUAL IMPLEMENTATIONS
@@ -305,6 +307,8 @@ private:
     std::atomic_flag                    _terminated;
     std::atomic_int                     _signal;
     Traits::Yield*                      _yield;
+    std::chrono::microseconds           _sleepDuration;
+    std::chrono::high_resolution_clock::time_point  _sleepTimestamp;
 };
 
 template <class RET>

--- a/src/quantum/quantum_io_task.h
+++ b/src/quantum/quantum_io_task.h
@@ -65,6 +65,7 @@ public:
     int getQueueId() final;
     Type getType() const final;
     bool isBlocked() const final;
+    bool isSleeping(bool updateTimer = false) final;
     bool isHighPriority() const final;
     
     //===================================

--- a/src/quantum/quantum_task.h
+++ b/src/quantum/quantum_task.h
@@ -74,6 +74,7 @@ public:
     int getQueueId() final;
     Type getType() const final;
     bool isBlocked() const final;
+    bool isSleeping(bool updateTimer = false) final;
     bool isHighPriority() const final;
     
     //ITaskContinuation

--- a/src/quantum/quantum_task_queue.h
+++ b/src/quantum/quantum_task_queue.h
@@ -92,6 +92,7 @@ private:
     std::shared_ptr<std::thread>        _thread;
     TaskList                            _queue;
     TaskListIter                        _queueIt;
+    TaskListIter                        _blockedIt;
     mutable SpinLock                    _spinlock;
     std::mutex                          _notEmptyMutex; //for accessing the condition variable
     std::condition_variable             _notEmptyCond;

--- a/src/quantum/quantum_thread_traits.h
+++ b/src/quantum/quantum_thread_traits.h
@@ -39,6 +39,11 @@ struct ThreadTraits
         static std::chrono::milliseconds value(0);
         return value;
     }
+    static std::chrono::microseconds& yieldSleepIntervalUs()
+    {
+        static std::chrono::microseconds value(10);
+        return value;
+    }
 };
 
 }

--- a/src/quantum/quantum_yielding_thread.h
+++ b/src/quantum/quantum_yielding_thread.h
@@ -35,7 +35,7 @@ struct YieldingThreadDuration
     /// @brief Yields the current thread either via a busy wait loop or by sleeping it.
     ///        Behavior is determined at compile time.
     /// @param[in] time Time used for the sleep duration.
-    void operator()(DURATION time = std::chrono::duration_cast<DURATION>(ThreadTraits::yieldSleepIntervalMs()))
+    void operator()(DURATION time = defaultDuration())
     {
         if (time == DURATION(0)) {
             //Busy wait
@@ -46,9 +46,15 @@ struct YieldingThreadDuration
             std::this_thread::sleep_for(time);
         }
     }
+    
+    static DURATION defaultDuration()
+    {
+        return std::chrono::duration_cast<DURATION>(ThreadTraits::yieldSleepIntervalMs()) +
+               std::chrono::duration_cast<DURATION>(ThreadTraits::yieldSleepIntervalUs());
+    }
 };
 
-using YieldingThread = YieldingThreadDuration<std::chrono::milliseconds>;
+using YieldingThread = YieldingThreadDuration<std::chrono::microseconds>;
 
 }}
 

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -24,6 +24,7 @@
 
 using namespace quantum;
 using ms = std::chrono::milliseconds;
+using us = std::chrono::microseconds;
 constexpr int DispatcherSingleton::numCoro;
 constexpr int DispatcherSingleton::numThreads;
 Dispatcher* DispatcherSingleton::_dispatcher = nullptr;
@@ -44,8 +45,9 @@ int DummyIoTask(ThreadPromise<int>::Ptr promise)
     return 0;
 }
 
-int fibInput = 20;
-std::map<int, int> fibValues{{10, 55}, {20, 6765}, {25, 75025}, {30, 832040}};
+int fibInput = 23;
+std::map<int, int> fibValues{{10, 55}, {20, 6765}, {21, 10946}, {22, 17711},
+                             {23, 28657}, {24, 46368}, {25, 75025}, {30, 832040}};
 
 int sequential_fib(CoroContext<size_t>::Ptr ctx, size_t fib)
 {
@@ -61,6 +63,7 @@ int sequential_fib(CoroContext<size_t>::Ptr ctx, size_t fib)
 
 int recursive_fib(CoroContext<size_t>::Ptr ctx, size_t fib)
 {
+    ctx->sleep(us(100));
     if (fib <= 2)
     {
         return ctx->set(1);


### PR DESCRIPTION
Changes to reduce CPU overload when a coroutine sleeps or is blocked. 
Added microsecond precision (in classes `ThreadTraits::yieldSleepIntervalUs()` and `ICoroSync::sleep()`) for coroutine sleeping as well as yielding a non-coroutine thread.
Fixed race conditions in Sequencer tests.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>