### PR TITLE
Don't force -std=c++14 if not in CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ add_definitions(
 )
 
 #Set compile flags if they haven't been set via CXXFLAGS environment variable
-if (CMAKE_CXX_FLAGS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
-else()
+if (NOT CMAKE_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wabi -O0 -m${MODE} -std=c++${CMAKE_CXX_STANDARD} -ftemplate-backtrace-limit=0")
 endif()
 


### PR DESCRIPTION
Allow more flexibility when setting the build environment. `CXXFLAGS` environment variable can be set to contain all compile options.
Signed-off-by: Alexander Damian <adamian@bloomberg.net>