### PR TITLE
Updated quantum schema with the queue range for 'any'.

### DIFF
--- a/src/quantum/impl/quantum_configuration_impl.h
+++ b/src/quantum/impl/quantum_configuration_impl.h
@@ -64,6 +64,14 @@ const std::string& Configuration::getJsonSchema()
             "loadBalancePollIntervalNumBackoffs": {
                 "type": "number",
                 "default": 0
+            },
+            "coroQueueIdRangeForAnyLow": {
+                "type": "number",
+                "default": -1
+            },
+            "coroQueueIdRangeForAnyHigh": {
+                "type": "number",
+                "default": -1
             }
         },
         "additionalProperties": false,

--- a/src/quantum/quantum_configuration.h
+++ b/src/quantum/quantum_configuration.h
@@ -128,7 +128,7 @@ private:
     std::chrono::milliseconds   _loadBalancePollIntervalMs{100};
     BackoffPolicy               _loadBalancePollIntervalBackoffPolicy{BackoffPolicy::Linear};
     size_t                      _loadBalancePollIntervalNumBackoffs{0};
-    std::pair<int, int>         _coroQueueIdRangeForAny{0, -1};
+    std::pair<int, int>         _coroQueueIdRangeForAny{-1, -1};
 };
 
 }}


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>