### PR TITLE
Added default install directory for headers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ before_script:
 
 script:
   - cmake -DQUANTUM_ENABLE_TESTS=ON -DQUANTUM_BOOST_USE_VALGRIND=ON -DCMAKE_INSTALL_PREFIX=tests -DGTEST_ROOT=googletest/install .
-  - make install
   - make quantum_tests && ./tests/quantum_tests.Linux64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ option(QUANTUM_BOOST_USE_VALGRIND "Use valgrind headers for Boost." OFF)
 
 if (QUANTUM_INSTALL_ROOT)
     set(CMAKE_INSTALL_PREFIX ${QUANTUM_INSTALL_ROOT})
+else()
+    # Use local build folder
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install)
 endif()
 
 #Global options
@@ -93,8 +96,10 @@ if (Boost_FOUND)
         message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
     endif()
 else()
-    message(FATAL_ERROR "Boost not found")
+    message(FATAL_ERROR "Boost not found, please define BOOST_ROOT.")
 endif()
+
+add_subdirectory(src)
 
 if (QUANTUM_ENABLE_TESTS)
     find_package(GTest REQUIRED)
@@ -109,8 +114,6 @@ else()
     set(BUILD_TESTING OFF)
     message(STATUS "Skipping target 'tests'")
 endif()
-
-add_subdirectory(src)
 
 # Debug info
 if (QUANTUM_VERBOSE_MAKEFILE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,3 +51,7 @@ install(
     DESTINATION include/quantum/util/impl
     COMPONENT headers
 )
+add_custom_target(headers-install
+    COMMAND "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=headers -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+    EXCLUDE_FROM_ALL
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ link_directories(
     ${BOOST_ROOT}
     ${GTEST_ROOT}
 )
-add_executable(${TEST_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILES})
+add_executable(${TEST_TARGET} ${SOURCE_FILES})
+add_dependencies(${TEST_TARGET} headers-install)
 gtest_discover_tests(${TEST_TARGET}
                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(${TEST_TARGET}
@@ -25,11 +26,6 @@ set_target_properties(${TEST_TARGET}
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
     RUNTIME_OUTPUT_NAME "${TEST_TARGET}.${CMAKE_SYSTEM_NAME}${MODE}"
 )
-install(TARGETS ${TEST_TARGET}
-    RUNTIME DESTINATION ${PROJECT_SOURCE_DIR}/tests
-    COMPONENT tests
-    OPTIONAL EXCLUDE_FROM_ALL
-)
 if (QUANTUM_VERBOSE_MAKEFILE)
     message(STATUS "SOURCE_FILES = ${SOURCE_FILES}")
     get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
@@ -37,3 +33,6 @@ if (QUANTUM_VERBOSE_MAKEFILE)
     message(STATUS "INCLUDE_DIRECTORIES = ${inc_dirs}")
     message(STATUS "LINK_DIRECTORIES = ${link_dirs}")
 endif()
+add_custom_target(tests)
+add_dependencies(tests ${TEST_TARGET})
+add_test(${PROJECT_NAME} ${TEST_TARGET})


### PR DESCRIPTION
Added default install directory for headers to avoid having to run 'make install' before building test target

Signed-off-by: Alexander Damian <adamian@bloomberg.net>