### PR TITLE
Removed temp install folder. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,6 @@ option(QUANTUM_BOOST_USE_VALGRIND "Use valgrind headers for Boost." OFF)
 
 if (QUANTUM_INSTALL_ROOT)
     set(CMAKE_INSTALL_PREFIX ${QUANTUM_INSTALL_ROOT})
-else()
-    # Use local build folder
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install)
 endif()
 
 #Global options


### PR DESCRIPTION
Headers will be installed prior to build directly into the CMAKE_INSTALL_PREFIX location.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>