### PR TITLE
Coroutine sync support in ConditionVariable

### DIFF
--- a/quantum/impl/quantum_mutex_impl.h
+++ b/quantum/impl/quantum_mutex_impl.h
@@ -22,6 +22,18 @@
 namespace Bloomberg {
 namespace quantum {
 
+inline
+void yield(ICoroSync::Ptr sync)
+{
+    if (sync)
+    {
+        sync->getYieldHandle()();
+    }
+    else {
+        YieldingThread()();
+    }
+}
+
 //==============================================================================================
 //                                class Mutex
 //==============================================================================================
@@ -32,21 +44,21 @@ Mutex::Mutex()
 inline
 void Mutex::lock()
 {
-    lockImpl(YieldingThread());
+    lockImpl(nullptr);
 }
 
 inline
 void Mutex::lock(ICoroSync::Ptr sync)
 {
-    lockImpl(sync->getYieldHandle());
+    lockImpl(sync);
 }
 
-template <class YIELDING>
-void Mutex::lockImpl(YIELDING&& yield)
+inline
+void Mutex::lockImpl(ICoroSync::Ptr sync)
 {
     while (!tryLock())
     {
-        yield();
+        yield(sync);
     }
 }
 
@@ -132,14 +144,7 @@ Mutex::ReverseGuard::ReverseGuard(ICoroSync::Ptr sync,
 inline
 Mutex::ReverseGuard::~ReverseGuard()
 {
-    if (_sync)
-    {
-        _mutex.lock(_sync);
-    }
-    else
-    {
-        _mutex.lock();
-    }
+    _mutex.lock(_sync);
 }
 
 }}

--- a/quantum/quantum_condition_variable.h
+++ b/quantum/quantum_condition_variable.h
@@ -60,8 +60,16 @@ public:
     /// @brief Notify one waiting thread or coroutine.
     void notifyOne();
     
+    /// @brief Notify one waiting thread or coroutine.
+    /// @param[in] sync Pointer to a coroutine synchronization object.
+    void notifyOne(ICoroSync::Ptr sync);
+    
     /// @brief Notify all waiting threads and coroutines.
     void notifyAll();
+    
+    /// @brief Notify all waiting threads and coroutines.
+    /// @param[in] sync Pointer to a coroutine synchronization object.
+    void notifyAll(ICoroSync::Ptr sync);
     
     /// @brief Block the current thread until the condition is signalled via notifyOne() or notifyAll().
     /// @details When this function returns, the mutex is guaranteed to be locked.
@@ -195,29 +203,28 @@ public:
                  PREDICATE predicate);
     
 private:
-    template <class YIELDING>
-    void waitImpl(YIELDING&& yield,
-                  Mutex& mutex,
-                  std::atomic_int& signal);
+    void notifyOneImpl(ICoroSync::Ptr sync);
     
-    template <class YIELDING, class PREDICATE = bool()>
-    void waitImpl(YIELDING&& yield,
-                  Mutex& mutex,
-                  PREDICATE predicate,
-                  std::atomic_int& signal);
+    void notifyAllImpl(ICoroSync::Ptr sync);
     
-    template <class YIELDING, class REP, class PERIOD>
-    bool waitForImpl(YIELDING&& yield,
+    void waitImpl(ICoroSync::Ptr sync,
+                  Mutex& mutex);
+    
+    template <class PREDICATE = bool()>
+    void waitImpl(ICoroSync::Ptr sync,
+                  Mutex& mutex,
+                  PREDICATE predicate);
+    
+    template <class REP, class PERIOD>
+    bool waitForImpl(ICoroSync::Ptr sync,
                      Mutex& mutex,
-                     std::chrono::duration<REP, PERIOD>& time,
-                     std::atomic_int& signal);
+                     std::chrono::duration<REP, PERIOD>& time);
     
-    template <class YIELDING, class REP, class PERIOD, class PREDICATE = bool()>
-    bool waitForImpl(YIELDING&& yield,
+    template <class REP, class PERIOD, class PREDICATE = bool()>
+    bool waitForImpl(ICoroSync::Ptr sync,
                      Mutex& mutex,
                      const std::chrono::duration<REP, PERIOD>& time,
-                     PREDICATE predicate,
-                     std::atomic_int& signal);
+                     PREDICATE predicate);
     
     //MEMBERS
     Mutex                           _thisLock; //sync access to this object

--- a/quantum/quantum_mutex.h
+++ b/quantum/quantum_mutex.h
@@ -139,8 +139,7 @@ public:
     };
     
 private:
-    template <class YIELDING>
-    void lockImpl(YIELDING&& yield);
+    void lockImpl(ICoroSync::Ptr sync);
     
     //Members
     mutable SpinLock  _spinlock;


### PR DESCRIPTION
Description:
- Added coroutine synchronization for ConditionVariable::notifyOne() and
ConditionVariable::notifyAll().
- Fixed Mutex locking so that coroutines yield instead of microsleeping
the current thread.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>