### PR TITLE
Passing coroutine context into forEach and mapReduce with type Void.

### DIFF
--- a/quantum/impl/quantum_stl_impl.h
+++ b/quantum/impl/quantum_stl_impl.h
@@ -65,6 +65,14 @@ namespace std {
     template<typename... _Types>
     using index_sequence_for = make_index_sequence<sizeof...(_Types)>;
 #endif
+#if (__cplusplus <= 201703L)
+    template<class T, class U>
+    std::shared_ptr<T> reinterpret_pointer_cast(const std::shared_ptr<U>& r) noexcept
+    {
+        auto p = reinterpret_cast<typename std::shared_ptr<T>::element_type*>(r.get());
+        return std::shared_ptr<T>(r, p);
+    }
+#endif
 } //std
 
 namespace Bloomberg {

--- a/quantum/interface/quantum_icoro_context.h
+++ b/quantum/interface/quantum_icoro_context.h
@@ -348,7 +348,7 @@ struct ICoroContext : public ICoroContextBase
     ///        This function runs in parallel.
     /// @tparam OTHER_RET The return value of the unary function.
     /// @tparam INPUT_IT The type of iterator.
-    /// @tparam FUNC A unary function of type 'RET(*INPUT_IT)'.
+    /// @tparam FUNC A unary function of type 'RET(VoidContextPtr, *INPUT_IT)'.
     /// @param[in] first The first element in the range.
     /// @param[in] last The last element in the range (exclusive).
     /// @param[in] func The unary function.
@@ -356,6 +356,8 @@ struct ICoroContext : public ICoroContextBase
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator
     /// @note Each func invocation will run inside its own coroutine instance.
     ///       Prefer this function over forEachBatch() if performing IO inside FUNC.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class OTHER_RET = int,
               class INPUT_IT,
               class FUNC,
@@ -371,14 +373,9 @@ struct ICoroContext : public ICoroContextBase
     typename ICoroContext<std::vector<OTHER_RET>>::Ptr
     forEach(INPUT_IT first, size_t num, FUNC&& func);
     
-    /// @brief Applies the given unary function to all the elements in the range [first,last).
-    ///        This function runs serially with respect to other functions in the same batch.
-    /// @tparam OTHER_RET The return value of the unary function.
-    /// @tparam UNARY_FUNC A unary function of type 'RET(*INPUT_IT)'.
-    /// @tparam InputIt The type of iterator.
-    /// @oaram[in] first The first element in the range.
-    /// @oaram[in] last The last element in the range (exclusive).
-    /// @oaram[in] func The unary function.
+    /// @brief The batched version of forEach(). This function applies the given unary function
+    ///        to all the elements in the range [first,last). This function runs serially with respect
+    ///        to other functions in the same batch.
     /// @return A vector of value vectors (i.e. one per batch).
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
     /// @note The input range is split equally among coroutines and executed in batches. This function
@@ -403,9 +400,9 @@ struct ICoroContext : public ICoroContextBase
     /// @tparam MAPPED_TYPE The output type after a map operation.
     /// @tparam REDUCED_TYPE The output type after a reduce operation.
     /// @tparam MAPPER_FUNC The mapper function having the signature
-    ///         'std::vector<std::pair<KEY,MAPPED_TYPE>>(*INPUT_IT)'
+    ///         'std::vector<std::pair<KEY,MAPPED_TYPE>>(VoidContextPtr, *INPUT_IT)'
     /// @tparam REDUCER_FUNC The reducer function having the signature
-    ///         'std::pair<KEY,REDUCED_TYPE>(std::pair<KEY, std::vector<MAPPED_TYPE>>&&)'
+    ///         'std::pair<KEY,REDUCED_TYPE>(VoidContextPtr, std::pair<KEY, std::vector<MAPPED_TYPE>>&&)'
     /// @tparam INPUT_IT The iterator type.
     /// @oaram[in] first The start iterator to a list of items to be processed in the range [first,last).
     /// @oaram[in] last The end iterator to a list of items (not inclusive).
@@ -413,6 +410,8 @@ struct ICoroContext : public ICoroContextBase
     /// @oaram[in] reducer The reducer function.
     /// @return A future to a reduced map of values.
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class KEY,
               class MAPPED_TYPE,
               class REDUCED_TYPE,

--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -166,7 +166,7 @@ public:
     ///        This function runs in parallel.
     /// @tparam RET The return value of the unary function.
     /// @tparam INPUT_IT The type of iterator.
-    /// @tparam FUNC A unary function of type 'RET(*INPUT_IT)'.
+    /// @tparam FUNC A unary function of type 'RET(VoidContextPtr, *INPUT_IT)'.
     /// @oaram[in] first The first element in the range.
     /// @oaram[in] last The last element in the range (exclusive).
     /// @oaram[in] func The unary function.
@@ -174,6 +174,8 @@ public:
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator
     /// @note Each func invocation will run inside its own coroutine instance.
     ///       Prefer this function over forEachBatch() if performing IO inside FUNC.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class RET = int,
               class INPUT_IT,
               class FUNC,
@@ -216,9 +218,9 @@ public:
     /// @tparam MAPPED_TYPE The output type after a map operation.
     /// @tparam REDUCED_TYPE The output type after a reduce operation.
     /// @tparam MAPPER_FUNC The mapper function having the signature
-    ///         'std::vector<std::pair<KEY,MAPPED_TYPE>>(*INPUT_IT)'
+    ///         'std::vector<std::pair<KEY,MAPPED_TYPE>>(VoidContextPtr, *INPUT_IT)'
     /// @tparam REDUCER_FUNC The reducer function having the signature
-    ///         'std::pair<KEY,REDUCED_TYPE>(std::pair<KEY, std::vector<MAPPED_TYPE>>&&)'
+    ///         'std::pair<KEY,REDUCED_TYPE>(VoidContextPtr, std::pair<KEY, std::vector<MAPPED_TYPE>>&&)'
     /// @tparam INPUT_IT The iterator type.
     /// @oaram[in] first The start iterator to a list of items to be processed in the range [first,last).
     /// @oaram[in] last The end iterator to a list of items (not inclusive).
@@ -226,6 +228,8 @@ public:
     /// @oaram[in] reducer The reducer function.
     /// @return A future to a reduced map of values.
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class KEY,
               class MAPPED_TYPE,
               class REDUCED_TYPE,

--- a/quantum/quantum_functions.h
+++ b/quantum/quantum_functions.h
@@ -23,6 +23,11 @@
 namespace Bloomberg {
 namespace quantum {
 
+struct Void{};
+template <typename T>
+struct ICoroContext;
+using VoidContextPtr = std::shared_ptr<ICoroContext<Void>>;
+
 //==============================================================================================
 //                                    struct Functions
 //==============================================================================================
@@ -31,13 +36,16 @@ namespace quantum {
 struct Functions
 {
     template <class RET, class INPUT_IT>
-    using ForEachFunc = std::function<RET(const typename std::iterator_traits<INPUT_IT>::value_type&)>;
+    using ForEachFunc = std::function<RET(VoidContextPtr,
+                                          const typename std::iterator_traits<INPUT_IT>::value_type&)>;
     
     template <class KEY, class MAPPED_TYPE, class INPUT_IT>
-    using MapFunc = std::function<std::vector<std::pair<KEY, MAPPED_TYPE>>(const typename std::iterator_traits<INPUT_IT>::value_type&)>;
+    using MapFunc = std::function<std::vector<std::pair<KEY, MAPPED_TYPE>>(VoidContextPtr,
+                                                                           const typename std::iterator_traits<INPUT_IT>::value_type&)>;
     
     template <class KEY, class MAPPED_TYPE, class REDUCED_TYPE>
-    using ReduceFunc = std::function<std::pair<KEY, REDUCED_TYPE>(std::pair<KEY, std::vector<MAPPED_TYPE>>&&)>;
+    using ReduceFunc = std::function<std::pair<KEY, REDUCED_TYPE>(VoidContextPtr,
+                                                                  std::pair<KEY, std::vector<MAPPED_TYPE>>&&)>;
 };
 
 }}

--- a/quantum/util/quantum_sequencer.h
+++ b/quantum/util/quantum_sequencer.h
@@ -55,15 +55,17 @@ public:
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine
     ///          associated with the same 'sequenceKey' completes. If there are none, it will run immediately.
     ///          (@see Dispatcher::post for more details).
-    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine with signature 'int(VoidContextPtr, Args...)'
     /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
     /// @param[in] sequenceKey SequenceKey object that the posted task is associated with
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately.
-    /// @remark For lowering the latencies of processing tasks posted here, it is suggested that the configured
-    /// Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
-    /// the control queue id (@see SequencerConfiguration::setControlQueueId).
+    /// @note For lowering the latencies of processing tasks posted here, it is suggested that the configured
+    ///       Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
+    ///       the control queue id (@see SequencerConfiguration::setControlQueueId).
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
     post(const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
@@ -72,7 +74,7 @@ public:
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine
     ///          associated with the same 'sequenceKey' completes. If there are none, it will run immediately.
     ///          (@see Dispatcher::post for more details).
-    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine with signature 'int(VoidContextPtr, Args...)'
     /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
     /// @param[in] queueId Id of the queue where this coroutine should run. Note that the user can
     ///                    specify IQueue::QueueId::Any as a value, which is equivalent to running
@@ -86,11 +88,13 @@ public:
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately.
-    /// @remark For lowering the latencies of processing tasks posted here, queueId is suggested to be
-    /// different from the control queue id (@see SequencerConfiguration::setControlQueueId). Hence, if
-    /// IQueue::QueueId::Any is intended to be used as queueId here, then it is suggested that the configured
-    /// Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
-    /// the control queue id.
+    /// @note For lowering the latencies of processing tasks posted here, queueId is suggested to be
+    ///       different from the control queue id (@see SequencerConfiguration::setControlQueueId). Hence, if
+    ///       IQueue::QueueId::Any is intended to be used as queueId here, then it is suggested that the configured
+    ///       Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
+    ///       the control queue id.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
     post(void* opaque, int queueId, bool isHighPriority, const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
@@ -99,15 +103,17 @@ public:
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine(s)
     ///          associated with all the 'sequenceKeys' complete. If there are none, then it will run immediately.
     ///          (@see Dispatcher::post for more details).
-    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine with signature 'int(VoidContextPtr, Args...)'
     /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
     /// @param[in] sequenceKeys A collection of sequenceKey objects that the posted task is associated with
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately.
-    /// @remark For lowering the latencies of processing tasks posted here, it is suggested that the configured
-    /// Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
-    /// the control queue id (@see SequencerConfiguration::setControlQueueId).
+    /// @note For lowering the latencies of processing tasks posted here, it is suggested that the configured
+    ///       Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
+    ///       the control queue id (@see SequencerConfiguration::setControlQueueId).
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
     post(const std::vector<SequenceKey>& sequenceKeys, FUNC&& func, ARGS&&... args);
@@ -116,7 +122,7 @@ public:
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine(s)
     ///          associated with all the 'sequenceKeys' complete. If there are none, then it will run immediately.
     ///          (@see Dispatcher::post for more details).
-    /// @tparam FUNC Callable object type which will be wrapped in a coroutine.
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine with signature 'int(VoidContextPtr, Args...)'
     /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
     /// @param[in] queueId Id of the queue where this coroutine should run. Note that the user 
     ///                    can specify IQueue::QueueId::Any as a value, which is equivalent to running 
@@ -130,11 +136,13 @@ public:
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately.
-    /// @remark For lowering the latencies of processing tasks posted here, queueId is suggested to be
-    /// different from the control queue id (@see SequencerConfiguration::setControlQueueId). Hence, if
-    /// IQueue::QueueId::Any is intended to be used as queueId here, then it is suggested that the configured
-    /// Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
-    /// the control queue id.
+    /// @note For lowering the latencies of processing tasks posted here, queueId is suggested to be
+    ///       different from the control queue id (@see SequencerConfiguration::setControlQueueId). Hence, if
+    ///       IQueue::QueueId::Any is intended to be used as queueId here, then it is suggested that the configured
+    ///       Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
+    ///       the control queue id.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
     post(void* opaque,
@@ -148,14 +156,16 @@ public:
     /// @details This method will post the coroutine on any thread available. The posted task is assumed to be associated
     ///          with the entire universe of sequenceKeys already running or pending, which means that it will wait
     ///          until all tasks complete. This task can be considered as having a 'universal' key.
-    /// @tparam FUNC Callable object type which will be wrapped in a coroutine
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine with signature 'int(VoidContextPtr, Args...)'
     /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately.
-    /// @remark For lowering the latencies of processing tasks posted here, it is suggested that the configured
-    /// Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
-    /// the control queue id (@see SequencerConfiguration::setControlQueueId).
+    /// @note For lowering the latencies of processing tasks posted here, it is suggested that the configured
+    ///       Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
+    ///       the control queue id (@see SequencerConfiguration::setControlQueueId).
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
     postAll(FUNC&& func, ARGS&&... args);
@@ -164,7 +174,7 @@ public:
     /// @details This method will post the coroutine on any thread available. The posted task is assumed to be associated
     ///          with the entire universe of sequenceKeys already running or pending, which means that it will wait
     ///          until all tasks complete. This task can be considered as having a 'universal' key.
-    /// @tparam FUNC Callable object type which will be wrapped in a coroutine.
+    /// @tparam FUNC Callable object type which will be wrapped in a coroutine with signature 'int(VoidContextPtr, Args...)'
     /// @tparam ARGS Argument types passed to FUNC (@see Dispatcher::post for more details).
     /// @param[in] queueId Id of the queue where this coroutine should run. Note that the user 
     ///                    can specify IQueue::QueueId::Any as a value, which is equivalent to running 
@@ -177,11 +187,13 @@ public:
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately.
-    /// @remark For lowering the latencies of processing tasks posted here, queueId is suggested to be
-    /// different from the control queue id (@see SequencerConfiguration::setControlQueueId). Hence, if
-    /// IQueue::QueueId::Any is intended to be used as queueId here, then it is suggested that the configured
-    /// Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
-    /// the control queue id.
+    /// @note For lowering the latencies of processing tasks posted here, queueId is suggested to be
+    ///       different from the control queue id (@see SequencerConfiguration::setControlQueueId). Hence, if
+    ///       IQueue::QueueId::Any is intended to be used as queueId here, then it is suggested that the configured
+    ///       Any-coroutine-queue-range (@see Configuration::setCoroQueueIdRangeForAny) does not contain
+    ///       the control queue id.
+    /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
+    ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
     postAll(void* opaque, int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
@@ -220,7 +232,7 @@ private:
     using ExceptionCallback = typename Configuration::ExceptionCallback;
 
     template <class FUNC, class ... ARGS>
-    static int waitForTwoDependents(CoroContextPtr<int> ctx,
+    static int waitForTwoDependents(VoidContextPtr ctx,
                                     void* opaque,
                                     Sequencer& sequencer,
                                     SequenceKeyData&& dependent,
@@ -228,7 +240,7 @@ private:
                                     FUNC&& func,
                                     ARGS&&... args);
     template <class FUNC, class ... ARGS>
-    static int waitForDependents(CoroContextPtr<int> ctx,
+    static int waitForDependents(VoidContextPtr ctx,
                                  void* opaque,
                                  Sequencer& sequencer,
                                  std::vector<SequenceKeyData>&& dependents,
@@ -236,7 +248,7 @@ private:
                                  FUNC&& func,
                                  ARGS&&... args);
     template <class FUNC, class ... ARGS>
-    static int waitForUniversalDependent(CoroContextPtr<int> ctx,
+    static int waitForUniversalDependent(VoidContextPtr ctx,
                                          void* opaque,
                                          Sequencer& sequencer,
                                          std::vector<SequenceKeyData>&& dependents,
@@ -245,7 +257,7 @@ private:
                                          ARGS&&... args);
     template <class FUNC, class ... ARGS>
     static int singleSequenceKeyTaskScheduler(
-                                    CoroContextPtr<int> ctx,
+                                    VoidContextPtr ctx,
                                     void* opaque,
                                     int queueId,
                                     bool isHighPriority,
@@ -255,7 +267,7 @@ private:
                                     ARGS&&... args);
     template <class FUNC, class ... ARGS>
     static int multiSequenceKeyTaskScheduler(
-                                    CoroContextPtr<int> ctx,
+                                    VoidContextPtr ctx,
                                     void* opaque,
                                     int queueId,
                                     bool isHighPriority,
@@ -265,7 +277,7 @@ private:
                                     ARGS&&... args);
     template <class FUNC, class ... ARGS>
     static int universalTaskScheduler(
-                                    CoroContextPtr<int> ctx,
+                                    VoidContextPtr ctx,
                                     void* opaque,
                                     int queueId,
                                     bool isHighPriority,
@@ -273,7 +285,7 @@ private:
                                     FUNC&& func,
                                     ARGS&&... args);
     template <class FUNC, class ... ARGS>
-    static void callPosted(CoroContextPtr<int> ctx,
+    static int callPosted(VoidContextPtr ctx,
                            void* opaque,
                            const Sequencer& sequencer,
                            FUNC&& func,

--- a/quantum/util/quantum_util.h
+++ b/quantum/util/quantum_util.h
@@ -52,6 +52,9 @@ struct Util
     static Function<int()>
     bindIoCaller(std::shared_ptr<Promise<RET>> promise, FUNC&& func0, ARGS&& ...args0);
     
+    template <typename RET>
+    static VoidContextPtr makeVoidContext(CoroContextPtr<RET> ctx);
+    
     //------------------------------------------------------------------------------------------
     //                                      ForEach
     //------------------------------------------------------------------------------------------

--- a/tests/sequencer_tests.cpp
+++ b/tests/sequencer_tests.cpp
@@ -53,27 +53,27 @@ public: // types
         EXPECT_LE(beforeTaskIt->second.endTime, afterTaskIt->second.startTime);
     }
     
-    std::function<int(CoroContext<int>::Ptr)> makeTask(TaskId taskId)
+    std::function<void(VoidContextPtr)> makeTask(TaskId taskId)
     {
-        return [this, taskId](CoroContext<int>::Ptr ctx)
+        return [this, taskId](VoidContextPtr ctx)
         {
-            return taskFunc(ctx, taskId, nullptr, "");
+            taskFunc(ctx, taskId, nullptr, "");
         };
     }
 
-    std::function<int(CoroContext<int>::Ptr)> makeTaskWithBlock(TaskId taskId, std::atomic<bool>* blockFlag)
+    std::function<void(VoidContextPtr)> makeTaskWithBlock(TaskId taskId, std::atomic<bool>* blockFlag)
     {
-        return [this, taskId, blockFlag](CoroContext<int>::Ptr ctx)
+        return [this, taskId, blockFlag](VoidContextPtr ctx)
         {
-            return taskFunc(ctx, taskId, blockFlag, "");
+            taskFunc(ctx, taskId, blockFlag, "");
         };
     }
 
-    std::function<int(CoroContext<int>::Ptr)> makeTaskWithException(TaskId taskId, std::string error)
+    std::function<void(VoidContextPtr)> makeTaskWithException(TaskId taskId, std::string error)
     {
-        return [this, taskId, error](CoroContext<int>::Ptr ctx)
+        return [this, taskId, error](VoidContextPtr ctx)
         {
-            return taskFunc(ctx, taskId, nullptr, error);
+            taskFunc(ctx, taskId, nullptr, error);
         };
     }
 
@@ -89,7 +89,7 @@ public: // types
     
 private: // methods
 
-    int taskFunc(CoroContext<int>::Ptr ctx, TaskId id, std::atomic<bool>* blockFlag, std::string error)
+    void taskFunc(VoidContextPtr ctx, TaskId id, std::atomic<bool>* blockFlag, std::string error)
     {
         std::chrono::system_clock::time_point startTime = std::chrono::system_clock::now();
         do {
@@ -105,7 +105,6 @@ private: // methods
         
         _results[id].startTime = startTime;
         _results[id].endTime = endTime;
-        return ctx->set(0);
     }
 
 private: // members
@@ -271,13 +270,13 @@ TEST(Sequencer, SequenceKeyStats)
         }
     }
 
-    auto halfWayDoneJob = [](CoroContext<int>::Ptr ctx)->int
+    auto halfWayDoneJob = [](VoidContextPtr)->int
     {
-        return ctx->set(0);
+        return 0;
     };
     // this task will be done when all the tasks posted above
     // are scheduled because it's posted to the same controlQueueId
-    DispatcherSingleton::instance().post<int>(controlQueueId, false, std::move(halfWayDoneJob))->wait();
+    DispatcherSingleton::instance().post<Void>(controlQueueId, false, std::move(halfWayDoneJob))->wait();
 
     // make sure all the enqueued tasks are pending
     size_t postedCount = 0;


### PR DESCRIPTION
* Passing coroutine context into `forEach` and `mapReduce` with type `Void`.
* Changed `Sequencer` function signature to ignore context type since it was
not needed anyway.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>