### PR TITLE
Support for alternative V2 API offering a simpler coroutine signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 * Fast pre-allocated memory pools for internal objects and coroutines.
 * Parallel `forEach` and `mapReduce` functions.
 * Various stats API.
-* **NEW** `Sequencer` class allowing strict FIFO ordering of tasks based on sequence ids.
+* `Sequencer` class allowing strict FIFO ordering of tasks based on sequence ids.
+* **NEW** Added support for simpler V2 coroutine API which returns computed values [directly](https://github.com/bloomberg/quantum/wiki/4.-Quick-reference-guide).
 
 ### Sample code
 **Quantum** is very simple and easy to use:
@@ -71,6 +72,24 @@ std::list<int>& listRef = ctx->getRefAt<std::list<int>>(3); //get list reference
 std::list<int>& listRef2 = ctx->getRef(); //get another list reference.
                                           //The 'At' overload is optional for last chain future
 std::list<int> listValue = ctx->get(); //get list value
+```
+Chaining with the **new** V2 api and using 'auto':
+```c++
+using namespace Bloomberg::quantum;
+
+// Create a dispatcher
+Dispatcher dispatcher;
+
+auto ctx = dispatcher.postFirst2([](auto ctx)->int {
+    return 55; //Set the 1st value
+})->then2<double>([](auto ctx)->double {
+    // Get the first value and add something to it
+    return ctx->getPrev<int>() + 22.33; //Set the 2nd value
+})->then2<std::string>([](auto ctx)->std::string {
+    return "Hello world!"; //Set the 3rd value
+})->finally2<std::list<int>>([](auto ctx)->std::list<int> {
+    return {1,2,3}; //Set 4th value
+})->end();
 ```
 
 ### Building and installing

--- a/quantum/impl/quantum_capture_impl.h
+++ b/quantum/impl/quantum_capture_impl.h
@@ -25,23 +25,23 @@ namespace quantum {
 //==============================================================================================
 //                                   class Capture
 //==============================================================================================
-template <typename FUNC, typename ... ARGS>
-Capture<FUNC,ARGS...>::Capture(FUNC&& func, ARGS&&...args) :
+template <typename RET, typename FUNC, typename ... ARGS>
+Capture<RET,FUNC,ARGS...>::Capture(FUNC&& func, ARGS&&...args) :
     _func(std::forward<FUNC>(func)),
     _args(std::forward<ARGS>(args)...) //pack
 {}
 
-template <typename FUNC, typename ... ARGS>
+template <typename RET, typename FUNC, typename ... ARGS>
 template <typename ... T>
-int Capture<FUNC,ARGS...>::operator()(T&&...t) {
-     return apply<int>(_func, std::move(_args), std::forward<T>(t)...); //fwd
+RET Capture<RET,FUNC,ARGS...>::operator()(T&&...t) {
+     return apply<RET>(_func, std::move(_args), std::forward<T>(t)...); //fwd
 }
 
-template <typename FUNC, typename ... ARGS>
-Capture<FUNC, ARGS...>
+template <typename RET, typename FUNC, typename ... ARGS>
+Capture<RET,FUNC,ARGS...>
 makeCapture(FUNC&& func, ARGS&& ... args)
 {
-    return Capture<FUNC, ARGS...>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return Capture<RET,FUNC,ARGS...>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 //==============================================================================================

--- a/quantum/impl/quantum_context_impl.h
+++ b/quantum/impl/quantum_context_impl.h
@@ -111,6 +111,14 @@ IThreadContext<RET>::then(FUNC&& func, ARGS&&... args)
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 ThreadContextPtr<OTHER_RET>
+IThreadContext<RET>::then2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template then2<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ThreadContextPtr<OTHER_RET>
 IThreadContext<RET>::onError(FUNC&& func, ARGS&&... args)
 {
     return static_cast<Impl*>(this)->template onError<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
@@ -119,9 +127,25 @@ IThreadContext<RET>::onError(FUNC&& func, ARGS&&... args)
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 ThreadContextPtr<OTHER_RET>
+IThreadContext<RET>::onError2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template onError2<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ThreadContextPtr<OTHER_RET>
 IThreadContext<RET>::finally(FUNC&& func, ARGS&&... args)
 {
     return static_cast<Impl*>(this)->template finally<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ThreadContextPtr<OTHER_RET>
+IThreadContext<RET>::finally2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template finally2<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -231,7 +255,19 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::post(FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template post<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template post<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::post2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template post2<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -239,7 +275,23 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template post<OTHER_RET>(queueId, isHighPriority, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template post<OTHER_RET>(
+        queueId,
+        isHighPriority,
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template post2<OTHER_RET>(
+        queueId,
+        isHighPriority,
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -247,7 +299,19 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::postFirst(FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template postFirst<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template postFirst<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::postFirst2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template postFirst2<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -255,7 +319,23 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template postFirst<OTHER_RET>(queueId, isHighPriority, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template postFirst<OTHER_RET>(
+        queueId,
+        isHighPriority,
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template postFirst2<OTHER_RET>(
+        queueId,
+        isHighPriority,
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -263,7 +343,19 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::then(FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template then<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template then<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::then2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template then2<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -271,7 +363,19 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::onError(FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template onError<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template onError<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::onError2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template onError2<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -279,8 +383,21 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroContextPtr<OTHER_RET>
 ICoroContext<RET>::finally(FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template finally<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template finally<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroContextPtr<OTHER_RET>
+ICoroContext<RET>::finally2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template finally2<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
 
 template <class RET>
 typename ICoroContext<RET>::Ptr
@@ -294,7 +411,19 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 ICoroContext<RET>::postAsyncIo(FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template postAsyncIo<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template postAsyncIo<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroFuturePtr<OTHER_RET>
+ICoroContext<RET>::postAsyncIo2(FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template postAsyncIo2<OTHER_RET>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -302,7 +431,23 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return static_cast<Impl*>(this)->template postAsyncIo<OTHER_RET>(queueId, isHighPriority, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return static_cast<Impl*>(this)->template postAsyncIo<OTHER_RET>(
+        queueId,
+        isHighPriority,
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroFuturePtr<OTHER_RET>
+ICoroContext<RET>::postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    return static_cast<Impl*>(this)->template postAsyncIo2<OTHER_RET>(
+        queueId,
+        isHighPriority,
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -424,7 +569,7 @@ template <class RET>
 Context<RET>::Context(DispatcherCore& dispatcher) :
     _promises(1, PromisePtr<RET>(new Promise<RET>(), Promise<RET>::deleter)),
     _dispatcher(&dispatcher),
-    _terminated ATOMIC_FLAG_INIT,
+    _terminated(false),
     _signal(-1),
     _yield(nullptr),
     _sleepDuration(0)
@@ -435,7 +580,7 @@ template <class OTHER_RET>
 Context<RET>::Context(Context<OTHER_RET>& other) :
     _promises(other._promises),
     _dispatcher(other._dispatcher),
-    _terminated ATOMIC_FLAG_INIT,
+    _terminated(false),
     _signal(-1),
     _yield(nullptr),
     _sleepDuration(0)
@@ -452,7 +597,8 @@ Context<RET>::~Context()
 template <class RET>
 void Context<RET>::terminate()
 {
-    if (!_terminated.test_and_set())
+    bool value{false};
+    if (_terminated.compare_exchange_strong(value, true))
     {
         _promises.back()->terminate();
         
@@ -652,11 +798,48 @@ Context<RET>::thenImpl(ITask::Type type, FUNC&& func, ARGS&&... args)
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
+Context<RET>::thenImpl2(ITask::Type type, FUNC&& func, ARGS&&... args)
+{
+    auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*this),
+                                     Context<OTHER_RET>::deleter);
+    auto task = Task::Ptr(new Task(Void{},
+                                   ctx,
+                                   _task->getQueueId(),      //keep current queueId
+                                   _task->isHighPriority(),  //keep current priority
+                                   type,
+                                   std::forward<FUNC>(func),
+                                   std::forward<ARGS>(args)...),
+                          Task::deleter);
+    ctx->setTask(task);
+    
+    //Chain tasks
+    std::static_pointer_cast<ITaskContinuation>(_task)->setNextTask(task);
+    task->setPrevTask(std::static_pointer_cast<ITaskContinuation>(_task));
+    return ctx;
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
 Context<RET>::then(FUNC&& func, ARGS&&... args)
 {
     //Previous task must either be First or Continuation types
     validateTaskType(ITask::Type::Continuation);
-    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::Continuation, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::Continuation,
+                                              std::forward<FUNC>(func),
+                                              std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::then2(FUNC&& func, ARGS&&... args)
+{
+    //Previous task must either be First or Continuation types
+    validateTaskType(ITask::Type::Continuation);
+    return thenImpl2<OTHER_RET, FUNC, ARGS...>(ITask::Type::Continuation,
+                                               std::forward<FUNC>(func),
+                                               std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -665,7 +848,20 @@ ContextPtr<OTHER_RET>
 Context<RET>::onError(FUNC&& func, ARGS&&... args)
 {
     validateTaskType(ITask::Type::ErrorHandler);
-    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::ErrorHandler, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::ErrorHandler,
+                                              std::forward<FUNC>(func),
+                                              std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::onError2(FUNC&& func, ARGS&&... args)
+{
+    validateTaskType(ITask::Type::ErrorHandler);
+    return thenImpl2<OTHER_RET, FUNC, ARGS...>(ITask::Type::ErrorHandler,
+                                               std::forward<FUNC>(func),
+                                               std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -674,7 +870,20 @@ ContextPtr<OTHER_RET>
 Context<RET>::finally(FUNC&& func, ARGS&&... args)
 {
     validateTaskType(ITask::Type::Final);
-    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::Final, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::Final,
+                                              std::forward<FUNC>(func),
+                                              std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::finally2(FUNC&& func, ARGS&&... args)
+{
+    validateTaskType(ITask::Type::Final);
+    return thenImpl2<OTHER_RET, FUNC, ARGS...>(ITask::Type::Final,
+                                               std::forward<FUNC>(func),
+                                               std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -693,7 +902,21 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 Context<RET>::postAsyncIo(FUNC&& func, ARGS&&... args)
 {
-    return postAsyncIoImpl<OTHER_RET>((int)IQueue::QueueId::Any, false, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postAsyncIoImpl<OTHER_RET>((int)IQueue::QueueId::Any,
+                                      false,
+                                      std::forward<FUNC>(func),
+                                      std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroFuturePtr<OTHER_RET>
+Context<RET>::postAsyncIo2(FUNC&& func, ARGS&&... args)
+{
+    return postAsyncIoImpl2<OTHER_RET>((int)IQueue::QueueId::Any,
+                                       false,
+                                       std::forward<FUNC>(func),
+                                       std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -701,7 +924,21 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 Context<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return postAsyncIoImpl<OTHER_RET>(queueId, isHighPriority, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postAsyncIoImpl<OTHER_RET>(queueId,
+                                      isHighPriority,
+                                      std::forward<FUNC>(func),
+                                      std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroFuturePtr<OTHER_RET>
+Context<RET>::postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    return postAsyncIoImpl2<OTHER_RET>(queueId,
+                                       isHighPriority,
+                                       std::forward<FUNC>(func),
+                                       std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -715,6 +952,27 @@ Context<RET>::postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARG
     }
     auto promise = PromisePtr<OTHER_RET>(new Promise<OTHER_RET>(), Promise<OTHER_RET>::deleter);
     auto task = IoTask::Ptr(new IoTask(promise,
+                                       queueId,
+                                       isHighPriority,
+                                       std::forward<FUNC>(func),
+                                       std::forward<ARGS>(args)...),
+                            IoTask::deleter);
+    _dispatcher->postAsyncIo(task);
+    return promise->getICoroFuture();
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+CoroFuturePtr<OTHER_RET>
+Context<RET>::postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    if (queueId < (int)IQueue::QueueId::Any)
+    {
+        throw std::runtime_error("Invalid coroutine queue id");
+    }
+    auto promise = PromisePtr<OTHER_RET>(new Promise<OTHER_RET>(), Promise<OTHER_RET>::deleter);
+    auto task = IoTask::Ptr(new IoTask(Void{},
+                                       promise,
                                        queueId,
                                        isHighPriority,
                                        std::forward<FUNC>(func),
@@ -741,7 +999,7 @@ Context<RET>::forEach(INPUT_IT first,
                       size_t num,
                       FUNC&& func)
 {
-    return post<std::vector<OTHER_RET>>(Util::forEachCoro<OTHER_RET, INPUT_IT, FUNC&&>,
+    return post2<std::vector<OTHER_RET>>(Util::forEachCoro<OTHER_RET, INPUT_IT, FUNC&&>,
                                         INPUT_IT{first},
                                         size_t{num},
                                         std::forward<FUNC>(func));
@@ -764,7 +1022,7 @@ Context<RET>::forEachBatch(INPUT_IT first,
                            size_t num,
                            FUNC&& func)
 {
-    return post<std::vector<std::vector<OTHER_RET>>>(Util::forEachBatchCoro<OTHER_RET, INPUT_IT, FUNC&&>,
+    return post2<std::vector<std::vector<OTHER_RET>>>(Util::forEachBatchCoro<OTHER_RET, INPUT_IT, FUNC&&>,
                                                      INPUT_IT{first},
                                                      size_t{num},
                                                      std::forward<FUNC>(func),
@@ -798,7 +1056,7 @@ Context<RET>::mapReduce(INPUT_IT first,
                         Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
 {
     using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
-    return post<ReducerOutput>(Util::mapReduceCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
+    return post2<ReducerOutput>(Util::mapReduceCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
                                INPUT_IT{first},
                                size_t{num},
                                Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>{std::move(mapper)},
@@ -832,7 +1090,7 @@ Context<RET>::mapReduceBatch(INPUT_IT first,
                              Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
 {
     using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
-    return post<ReducerOutput>(Util::mapReduceBatchCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
+    return post2<ReducerOutput>(Util::mapReduceBatchCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
                                INPUT_IT{first},
                                size_t{num},
                                Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>{std::move(mapper)},
@@ -1076,7 +1334,22 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::post(FUNC&& func, ARGS&&... args)
 {
-    return postImpl<OTHER_RET>((int)IQueue::QueueId::Any, false, ITask::Type::Standalone, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<OTHER_RET>((int)IQueue::QueueId::Any,
+                               false, ITask::Type::Standalone,
+                               std::forward<FUNC>(func),
+                               std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::post2(FUNC&& func, ARGS&&... args)
+{
+    return postImpl2<OTHER_RET>((int)IQueue::QueueId::Any,
+                                false,
+                                ITask::Type::Standalone,
+                                std::forward<FUNC>(func),
+                                std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -1084,7 +1357,23 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return postImpl<OTHER_RET>(queueId, isHighPriority, ITask::Type::Standalone, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<OTHER_RET>(queueId,
+                               isHighPriority,
+                               ITask::Type::Standalone,
+                               std::forward<FUNC>(func),
+                               std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    return postImpl2<OTHER_RET>(queueId,
+                                isHighPriority,
+                                ITask::Type::Standalone,
+                                std::forward<FUNC>(func),
+                                std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -1092,7 +1381,24 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::postFirst(FUNC&& func, ARGS&&... args)
 {
-    return postImpl<OTHER_RET>((int)IQueue::QueueId::Any, false, ITask::Type::First, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<OTHER_RET>((int)IQueue::QueueId::Any,
+                               false,
+                               ITask::Type::First,
+                               std::forward<FUNC>(func),
+                               std::forward<ARGS>(args)...);
+}
+
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::postFirst2(FUNC&& func, ARGS&&... args)
+{
+    return postImpl2<OTHER_RET>((int)IQueue::QueueId::Any,
+                                false,
+                                ITask::Type::First,
+                                std::forward<FUNC>(func),
+                                std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -1100,7 +1406,23 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return postImpl<OTHER_RET>(queueId, isHighPriority, ITask::Type::First, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<OTHER_RET>(queueId,
+                               isHighPriority,
+                               ITask::Type::First,
+                               std::forward<FUNC>(func),
+                               std::forward<ARGS>(args)...);
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+{
+    return postImpl2<OTHER_RET>(queueId,
+                                isHighPriority,
+                                ITask::Type::First,
+                                std::forward<FUNC>(func),
+                                std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -1115,6 +1437,33 @@ Context<RET>::postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&
     auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*_dispatcher),
                                      Context<OTHER_RET>::deleter);
     auto task = Task::Ptr(new Task(ctx,
+                                   (queueId == (int)IQueue::QueueId::Same) ? _task->getQueueId() : queueId,
+                                   isHighPriority,
+                                   type,
+                                   std::forward<FUNC>(func),
+                                   std::forward<ARGS>(args)...),
+                          Task::deleter);
+    ctx->setTask(task);
+    if (type == ITask::Type::Standalone)
+    {
+        _dispatcher->post(task);
+    }
+    return ctx;
+}
+
+template <class RET>
+template <class OTHER_RET, class FUNC, class ... ARGS>
+ContextPtr<OTHER_RET>
+Context<RET>::postImpl2(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args)
+{
+    if (queueId < (int)IQueue::QueueId::Same)
+    {
+        throw std::runtime_error("Invalid coroutine queue id");
+    }
+    auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*_dispatcher),
+                                     Context<OTHER_RET>::deleter);
+    auto task = Task::Ptr(new Task(Void{},
+                                   ctx,
                                    (queueId == (int)IQueue::QueueId::Same) ? _task->getQueueId() : queueId,
                                    isHighPriority,
                                    type,

--- a/quantum/impl/quantum_dispatcher_impl.h
+++ b/quantum/impl/quantum_dispatcher_impl.h
@@ -28,7 +28,7 @@ inline
 Dispatcher::Dispatcher(const Configuration& config) :
     _dispatcher(config),
     _drain(false),
-    _terminated ATOMIC_FLAG_INIT
+    _terminated(false)
 {}
 
 inline
@@ -43,7 +43,23 @@ ThreadContextPtr<RET>
 Dispatcher::post(FUNC&& func,
                  ARGS&&... args)
 {
-    return postImpl<RET>((int)IQueue::QueueId::Any, false, ITask::Type::Standalone, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<RET>((int)IQueue::QueueId::Any,
+                         false,
+                         ITask::Type::Standalone,
+                         std::forward<FUNC>(func),
+                         std::forward<ARGS>(args)...);
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadContextPtr<RET>
+Dispatcher::post2(FUNC&& func,
+                  ARGS&&... args)
+{
+    return postImpl2<RET>((int)IQueue::QueueId::Any,
+                          false,
+                          ITask::Type::Standalone,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
@@ -53,7 +69,25 @@ Dispatcher::post(int queueId,
                  FUNC&& func,
                  ARGS&&... args)
 {
-    return postImpl<RET>(queueId, isHighPriority, ITask::Type::Standalone, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<RET>(queueId,
+                         isHighPriority,
+                         ITask::Type::Standalone,
+                         std::forward<FUNC>(func),
+                         std::forward<ARGS>(args)...);
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadContextPtr<RET>
+Dispatcher::post2(int queueId,
+                  bool isHighPriority,
+                  FUNC&& func,
+                  ARGS&&... args)
+{
+    return postImpl2<RET>(queueId,
+                          isHighPriority,
+                          ITask::Type::Standalone,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
@@ -61,7 +95,22 @@ ThreadContextPtr<RET>
 Dispatcher::postFirst(FUNC&& func,
                       ARGS&&... args)
 {
-    return postImpl<RET>((int)IQueue::QueueId::Any, false, ITask::Type::First, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<RET>((int)IQueue::QueueId::Any,
+                         false, ITask::Type::First,
+                         std::forward<FUNC>(func),
+                         std::forward<ARGS>(args)...);
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadContextPtr<RET>
+Dispatcher::postFirst2(FUNC&& func,
+                       ARGS&&... args)
+{
+    return postImpl2<RET>((int)IQueue::QueueId::Any,
+                          false,
+                          ITask::Type::First,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
@@ -71,7 +120,25 @@ Dispatcher::postFirst(int queueId,
                       FUNC&& func,
                       ARGS&&... args)
 {
-    return postImpl<RET>(queueId, isHighPriority, ITask::Type::First, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postImpl<RET>(queueId,
+                         isHighPriority,
+                         ITask::Type::First,
+                         std::forward<FUNC>(func),
+                         std::forward<ARGS>(args)...);
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadContextPtr<RET>
+Dispatcher::postFirst2(int queueId,
+                       bool isHighPriority,
+                       FUNC&& func,
+                       ARGS&&... args)
+{
+    return postImpl2<RET>(queueId,
+                          isHighPriority,
+                          ITask::Type::First,
+                          std::forward<FUNC>(func),
+                          std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
@@ -79,7 +146,20 @@ ThreadFuturePtr<RET>
 Dispatcher::postAsyncIo(FUNC&& func,
                         ARGS&&... args)
 {
-    return postAsyncIoImpl<RET>((int)IQueue::QueueId::Any, false, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postAsyncIoImpl<RET>((int)IQueue::QueueId::Any,
+                                false,
+                                std::forward<FUNC>(func),
+                                std::forward<ARGS>(args)...);
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadFuturePtr<RET>
+Dispatcher::postAsyncIo2(FUNC&& func,
+                         ARGS&&... args)
+{
+    return postAsyncIoImpl2<RET>((int)IQueue::QueueId::Any,
+                                 false, std::forward<FUNC>(func),
+                                 std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
@@ -89,7 +169,23 @@ Dispatcher::postAsyncIo(int queueId,
                         FUNC&& func,
                         ARGS&&... args)
 {
-    return postAsyncIoImpl<RET>(queueId, isHighPriority, std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    return postAsyncIoImpl<RET>(queueId,
+                                isHighPriority,
+                                std::forward<FUNC>(func),
+                                std::forward<ARGS>(args)...);
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadFuturePtr<RET>
+Dispatcher::postAsyncIo2(int queueId,
+                         bool isHighPriority,
+                         FUNC&& func,
+                         ARGS&&... args)
+{
+    return postAsyncIoImpl2<RET>(queueId,
+                                 isHighPriority,
+                                 std::forward<FUNC>(func),
+                                 std::forward<ARGS>(args)...);
 }
 
 template <class RET, class INPUT_IT, class FUNC, class>
@@ -107,10 +203,10 @@ Dispatcher::forEach(INPUT_IT first,
                     size_t num,
                     FUNC&& func)
 {
-    return post<std::vector<RET>>(Util::forEachCoro<RET, INPUT_IT, FUNC&&>,
-                                  INPUT_IT{first},
-                                  size_t{num},
-                                  std::forward<FUNC>(func));
+    return post2<std::vector<RET>>(Util::forEachCoro<RET, INPUT_IT, FUNC&&>,
+                                   INPUT_IT{first},
+                                   size_t{num},
+                                   std::forward<FUNC>(func));
 }
 
 template <class RET, class INPUT_IT, class FUNC, class>
@@ -128,7 +224,7 @@ Dispatcher::forEachBatch(INPUT_IT first,
                          size_t num,
                          FUNC&& func)
 {
-    return post<std::vector<std::vector<RET>>>(Util::forEachBatchCoro<RET, INPUT_IT, FUNC&&>,
+    return post2<std::vector<std::vector<RET>>>(Util::forEachBatchCoro<RET, INPUT_IT, FUNC&&>,
                                                INPUT_IT{first},
                                                size_t{num},
                                                std::forward<FUNC>(func),
@@ -160,7 +256,7 @@ Dispatcher::mapReduce(INPUT_IT first,
                       Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
 {
     using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
-    return post<ReducerOutput>(Util::mapReduceCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
+    return post2<ReducerOutput>(Util::mapReduceCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
                                INPUT_IT{first},
                                size_t{num},
                                Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>{std::move(mapper)},
@@ -192,7 +288,7 @@ Dispatcher::mapReduceBatch(INPUT_IT first,
                            Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
 {
     using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
-    return post<ReducerOutput>(Util::mapReduceBatchCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
+    return post2<ReducerOutput>(Util::mapReduceBatchCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
                                INPUT_IT{first},
                                size_t{num},
                                Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>{std::move(mapper)},
@@ -202,7 +298,8 @@ Dispatcher::mapReduceBatch(INPUT_IT first,
 inline
 void Dispatcher::terminate()
 {
-    if (!_terminated.test_and_set())
+    bool value{false};
+    if (_terminated.compare_exchange_strong(value, true))
     {
         _dispatcher.terminate();
     }
@@ -225,7 +322,7 @@ bool Dispatcher::empty(IQueue::QueueType type,
 inline
 void Dispatcher::drain(std::chrono::milliseconds timeout)
 {
-    _drain = true;
+    DrainGuard guard(_drain);
     
     auto start = std::chrono::high_resolution_clock::now();
     
@@ -251,7 +348,6 @@ void Dispatcher::drain(std::chrono::milliseconds timeout)
     std::lock_guard<std::mutex> guard(Util::LogMutex());
     std::cout << "All queues have drained." << std::endl;
 #endif
-    _drain = false;
 }
 
 inline
@@ -293,7 +389,7 @@ Dispatcher::postImpl(int queueId,
                      FUNC&& func,
                      ARGS&&... args)
 {
-    if (_drain)
+    if (_drain || _terminated)
     {
         throw std::runtime_error("Posting is disabled");
     }
@@ -319,13 +415,47 @@ Dispatcher::postImpl(int queueId,
 }
 
 template <class RET, class FUNC, class ... ARGS>
+ThreadContextPtr<RET>
+Dispatcher::postImpl2(int queueId,
+                      bool isHighPriority,
+                      ITask::Type type,
+                      FUNC&& func,
+                      ARGS&&... args)
+{
+    if (_drain || _terminated)
+    {
+        throw std::runtime_error("Posting is disabled");
+    }
+    if (queueId < (int)IQueue::QueueId::Any)
+    {
+        throw std::runtime_error("Invalid coroutine queue id");
+    }
+    auto ctx = ContextPtr<RET>(new Context<RET>(_dispatcher),
+                               Context<RET>::deleter);
+    auto task = Task::Ptr(new Task(Void{},
+                                   ctx,
+                                   queueId,
+                                   isHighPriority,
+                                   type,
+                                   std::forward<FUNC>(func),
+                                   std::forward<ARGS>(args)...),
+                          Task::deleter);
+    ctx->setTask(task);
+    if (type == ITask::Type::Standalone)
+    {
+        _dispatcher.post(task);
+    }
+    return std::static_pointer_cast<IThreadContext<RET>>(ctx);
+}
+
+template <class RET, class FUNC, class ... ARGS>
 ThreadFuturePtr<RET>
 Dispatcher::postAsyncIoImpl(int queueId,
                             bool isHighPriority,
                             FUNC&& func,
                             ARGS&&... args)
 {
-    if (_drain)
+    if (_drain || _terminated)
     {
         throw std::runtime_error("Posting is disabled");
     }
@@ -335,6 +465,33 @@ Dispatcher::postAsyncIoImpl(int queueId,
     }
     auto promise = PromisePtr<RET>(new Promise<RET>(), Promise<RET>::deleter);
     auto task = IoTask::Ptr(new IoTask(promise,
+                                       queueId,
+                                       isHighPriority,
+                                       std::forward<FUNC>(func),
+                                       std::forward<ARGS>(args)...),
+                            IoTask::deleter);
+    _dispatcher.postAsyncIo(task);
+    return promise->getIThreadFuture();
+}
+
+template <class RET, class FUNC, class ... ARGS>
+ThreadFuturePtr<RET>
+Dispatcher::postAsyncIoImpl2(int queueId,
+                             bool isHighPriority,
+                             FUNC&& func,
+                             ARGS&&... args)
+{
+    if (_drain || _terminated)
+    {
+        throw std::runtime_error("Posting is disabled");
+    }
+    if (queueId < (int)IQueue::QueueId::Any)
+    {
+        throw std::runtime_error("Invalid IO queue id");
+    }
+    auto promise = PromisePtr<RET>(new Promise<RET>(), Promise<RET>::deleter);
+    auto task = IoTask::Ptr(new IoTask(Void{},
+                                       promise,
                                        queueId,
                                        isHighPriority,
                                        std::forward<FUNC>(func),

--- a/quantum/impl/quantum_io_task_impl.h
+++ b/quantum/impl/quantum_io_task_impl.h
@@ -35,27 +35,26 @@ namespace quantum {
 
 template <class RET, class FUNC, class ... ARGS>
 IoTask::IoTask(std::shared_ptr<Promise<RET>> promise,
-               FUNC&& func,
-               ARGS&&... args) :
-    _func(Util::bindIoCaller(promise,
-                             std::forward<FUNC>(func),
-                             std::forward<ARGS>(args)...)),
-    _terminated ATOMIC_FLAG_INIT,
-    _queueId((int)IQueue::QueueId::Any),
-    _isHighPriority(false)
-{
-}
-
-template <class RET, class FUNC, class ... ARGS>
-IoTask::IoTask(std::shared_ptr<Promise<RET>> promise,
                int queueId,
                bool isHighPriority,
                FUNC&& func,
                ARGS&&... args) :
-    _func(Util::bindIoCaller(promise,
-                             std::forward<FUNC>(func),
-                             std::forward<ARGS>(args)...)),
-    _terminated ATOMIC_FLAG_INIT,
+    _func(Util::bindIoCaller(promise, std::forward<FUNC>(func), std::forward<ARGS>(args)...)),
+    _terminated(false),
+    _queueId(queueId),
+    _isHighPriority(isHighPriority)
+{
+}
+
+template <class RET, class FUNC, class ... ARGS>
+IoTask::IoTask(Void,
+               std::shared_ptr<Promise<RET>> promise,
+               int queueId,
+               bool isHighPriority,
+               FUNC&& func,
+               ARGS&&... args) :
+    _func(Util::bindIoCaller2(promise, std::forward<FUNC>(func), std::forward<ARGS>(args)...)),
+    _terminated(false),
     _queueId(queueId),
     _isHighPriority(isHighPriority)
 {
@@ -70,7 +69,8 @@ IoTask::~IoTask()
 inline
 void IoTask::terminate()
 {
-    if (!_terminated.test_and_set())
+    bool value{false};
+    if (_terminated.compare_exchange_strong(value, true))
     {
         //not used
     }

--- a/quantum/impl/quantum_promise_impl.h
+++ b/quantum/impl/quantum_promise_impl.h
@@ -89,7 +89,7 @@ Promise<T>::Promise() :
     IThreadPromise<Promise, T>(this),
     ICoroPromise<Promise, T>(this),
     _sharedState(new SharedState<T>()),
-    _terminated ATOMIC_FLAG_INIT
+    _terminated(false)
 {}
 
 template <class T>
@@ -101,7 +101,8 @@ Promise<T>::~Promise()
 template <class T>
 void Promise<T>::terminate()
 {
-    if (!_terminated.test_and_set())
+    bool value{false};
+    if (_terminated.compare_exchange_strong(value, true))
     {
         if (_sharedState) _sharedState->breakPromise();
     }

--- a/quantum/interface/quantum_icoro_context.h
+++ b/quantum/interface/quantum_icoro_context.h
@@ -35,7 +35,7 @@ class Context;
 /// @brief Exposes methods to manipulate the coroutine context.
 /// @tparam RET The type of value returned via the promise associated with this context.
 template <class RET>
-struct ICoroContext : public ICoroContextBase
+struct ICoroContext : ICoroContextBase
 {
     using ContextTag = CoroContextTag;
     using Ptr = std::shared_ptr<ICoroContext<RET>>;
@@ -185,6 +185,11 @@ struct ICoroContext : public ICoroContextBase
     typename ICoroContext<OTHER_RET>::Ptr
     post(FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    post2(FUNC&& func, ARGS&&... args);
+    
     /// @brief Post a coroutine to run asynchronously.
     /// @details This method will post the coroutine on the specified queue (thread) with high or low priority.
     /// @tparam OTHER_RET Type of future returned by this coroutine.
@@ -208,6 +213,11 @@ struct ICoroContext : public ICoroContextBase
     typename ICoroContext<OTHER_RET>::Ptr
     post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
     /// @brief Posts a coroutine to run asynchronously.
     /// @details This function is the head of a coroutine continuation chain and must be called only once in the chain.
     /// @tparam OTHER_RET Type of future returned by this coroutine.
@@ -223,6 +233,11 @@ struct ICoroContext : public ICoroContextBase
     template <class OTHER_RET = int, class FUNC, class ... ARGS>
     typename ICoroContext<OTHER_RET>::Ptr
     postFirst(FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    postFirst2(FUNC&& func, ARGS&&... args);
     
     /// @brief Posts a coroutine to run asynchronously.
     /// @details This function is the head of a coroutine continuation chain and must be called only once in the chain.
@@ -247,6 +262,11 @@ struct ICoroContext : public ICoroContextBase
     typename ICoroContext<OTHER_RET>::Ptr
     postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
     /// @brief Posts a coroutine to run asynchronously.
     /// @details This function is optional for the continuation chain and may be called 0 or more times. If called,
     ///          it must follow postFirst() or another then() method.
@@ -264,6 +284,11 @@ struct ICoroContext : public ICoroContextBase
     template <class OTHER_RET = int, class FUNC, class ... ARGS>
     typename ICoroContext<OTHER_RET>::Ptr
     then(FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    then2(FUNC&& func, ARGS&&... args);
     
     /// @brief Posts a coroutine to run asynchronously. This is the error handler for a continuation chain and acts as
     ///        as a 'catch' clause.
@@ -286,6 +311,11 @@ struct ICoroContext : public ICoroContextBase
     typename ICoroContext<OTHER_RET>::Ptr
     onError(FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    onError2(FUNC&& func, ARGS&&... args);
+    
     /// @brief Posts a coroutine to run asynchronously. This coroutine is always guaranteed to run.
     /// @details This function is optional for the continuation chain and may be called at most once. If called, it must
     ///          immediately precede the end() method. This method will run regardless if any preceding coroutines have
@@ -302,6 +332,11 @@ struct ICoroContext : public ICoroContextBase
     template <class OTHER_RET = int, class FUNC, class ... ARGS>
     typename ICoroContext<OTHER_RET>::Ptr
     finally(FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename ICoroContext<OTHER_RET>::Ptr
+    finally2(FUNC&& func, ARGS&&... args);
     
     /// @brief This is the last method in a continuation chain.
     /// @details This method effectively closes the continuation chain and posts the entire chain to be executed,
@@ -324,6 +359,11 @@ struct ICoroContext : public ICoroContextBase
     CoroFuturePtr<OTHER_RET>
     postAsyncIo(FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    CoroFuturePtr<OTHER_RET>
+    postAsyncIo2(FUNC&& func, ARGS&&... args);
+    
     /// @brief Posts an IO function to run asynchronously on the IO thread pool.
     /// @details This method will post the function on the specified queue (thread) with high or low priority.
     /// @tparam OTHER_RET Type of future returned by this function.
@@ -343,6 +383,11 @@ struct ICoroContext : public ICoroContextBase
     template <class OTHER_RET = int, class FUNC, class ... ARGS>
     CoroFuturePtr<OTHER_RET>
     postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    CoroFuturePtr<OTHER_RET>
+    postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     /// @brief Applies the given unary function to all the elements in the range [first,last).
     ///        This function runs in parallel.
@@ -468,6 +513,7 @@ using CoroContext = ICoroContext<RET>;
 
 template <class RET>
 using CoroContextPtr = typename ICoroContext<RET>::Ptr;
+using VoidContextPtr = CoroContextPtr<Void>;
 
 }}
 

--- a/quantum/interface/quantum_ithread_context.h
+++ b/quantum/interface/quantum_ithread_context.h
@@ -191,6 +191,11 @@ struct IThreadContext : public IThreadContextBase
     typename IThreadContext<OTHER_RET>::Ptr
     then(FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename IThreadContext<OTHER_RET>::Ptr
+    then2(FUNC&& func, ARGS&&... args);
+    
     /// @brief Posts a function to run asynchronously. This is the error handler for a continuation chain and acts as
     ///        as a 'catch' clause.
     /// @details This function is optional for the continuation chain and may be called at most once. If called,
@@ -211,6 +216,11 @@ struct IThreadContext : public IThreadContextBase
     typename IThreadContext<OTHER_RET>::Ptr
     onError(FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename IThreadContext<OTHER_RET>::Ptr
+    onError2(FUNC&& func, ARGS&&... args);
+    
     /// @brief Posts a function to run asynchronously. This function is always guaranteed to run.
     /// @details This function is optional for the continuation chain and may be called at most once. If called, it must
     ///          immediately precede the end() method. This method will run regardless if any preceding functions have
@@ -226,6 +236,11 @@ struct IThreadContext : public IThreadContextBase
     template <class OTHER_RET = int, class FUNC, class ... ARGS>
     typename IThreadContext<OTHER_RET>::Ptr
     finally(FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class OTHER_RET = int, class FUNC, class ... ARGS>
+    typename IThreadContext<OTHER_RET>::Ptr
+    finally2(FUNC&& func, ARGS&&... args);
     
     /// @brief This is the last method in a continuation chain.
     /// @details This method effectively closes the continuation chain and posts the entire chain to be executed,

--- a/quantum/quantum_capture.h
+++ b/quantum/quantum_capture.h
@@ -34,22 +34,22 @@ namespace quantum {
 /// @class Capture
 /// @brief Class allowing lambda parameter captures.
 /// @note For internal use only.
-template <typename FUNC, typename ... ARGS>
+template <typename RET, typename FUNC, typename ... ARGS>
 class Capture
 {
 public:
     Capture(FUNC&& func, ARGS&&...args);
 
     template <typename ... T>
-    int operator()(T&&...t);
+    RET operator()(T&&...t);
 private:
     FUNC                _func;
     std::tuple<ARGS...> _args;
 };
 
 //Helper function
-template <typename FUNC, typename ... ARGS>
-Capture<FUNC, ARGS...>
+template <typename RET, typename FUNC, typename ... ARGS>
+Capture<RET,FUNC,ARGS...>
 makeCapture(FUNC&& func, ARGS&& ... args);
 
 //==============================================================================================

--- a/quantum/quantum_context.h
+++ b/quantum/quantum_context.h
@@ -159,7 +159,15 @@ public:
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
+    post2(FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
     post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
+    post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
@@ -167,7 +175,15 @@ public:
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
+    postFirst2(FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
     postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
+    postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
@@ -175,11 +191,23 @@ public:
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
+    then2(FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
     onError(FUNC&& func, ARGS&&... args);
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
+    onError2(FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
     finally(FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
+    finally2(FUNC&& func, ARGS&&... args);
     
     Ptr end();
     
@@ -192,7 +220,15 @@ public:
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
     CoroFuturePtr<OTHER_RET>
+    postAsyncIo2(FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    CoroFuturePtr<OTHER_RET>
     postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    CoroFuturePtr<OTHER_RET>
+    postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     //===================================
     //           FOR EACH
@@ -276,14 +312,26 @@ private:
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
     thenImpl(ITask::Type type, FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
+    thenImpl2(ITask::Type type, FUNC&& func, ARGS&&... args);
 
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
     postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
+    typename Context<OTHER_RET>::Ptr
+    postImpl2(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
     CoroFuturePtr<OTHER_RET>
     postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    template <class OTHER_RET, class FUNC, class ... ARGS>
+    CoroFuturePtr<OTHER_RET>
+    postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     int index(int num) const;
     
@@ -295,7 +343,7 @@ private:
     ITask::Ptr                          _task;
     std::vector<IPromiseBase::Ptr>      _promises;
     DispatcherCore*                     _dispatcher;
-    std::atomic_flag                    _terminated;
+    std::atomic_bool                    _terminated;
     std::atomic_int                     _signal;
     Traits::Yield*                      _yield;
     std::chrono::microseconds           _sleepDuration;

--- a/quantum/quantum_contiguous_pool_manager.h
+++ b/quantum/quantum_contiguous_pool_manager.h
@@ -40,7 +40,7 @@ template <typename T>
 struct ContiguousPoolManager
 {
     template <typename U>
-    friend class ContiguousPoolManager;
+    friend struct ContiguousPoolManager;
     //------------------------------ Typedefs ----------------------------------
     typedef ContiguousPoolManager<T>        this_type;
     typedef T                               value_type;

--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -62,6 +62,12 @@ public:
     ThreadContextPtr<RET>
     post(FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class RET = int, class FUNC, class ... ARGS>
+    ThreadContextPtr<RET>
+    post2(FUNC&& func, ARGS&&... args);
+    
+    
     /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
     /// @tparam RET Type of future returned by this coroutine.
     /// @tparam FUNC Callable object type which will be wrapped in a coroutine. Can be a standalone function, a method,
@@ -82,6 +88,11 @@ public:
     ThreadContextPtr<RET>
     post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class RET = int, class FUNC, class ... ARGS>
+    ThreadContextPtr<RET>
+    post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
     /// @brief Post the first coroutine in a continuation chain to run asynchronously.
     /// @tparam RET Type of future returned by this coroutine.
     /// @tparam FUNC Callable object type which will be wrapped in a coroutine. Can be a standalone function, a method,
@@ -96,6 +107,11 @@ public:
     template <class RET = int, class FUNC, class ... ARGS>
     ThreadContextPtr<RET>
     postFirst(FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class RET = int, class FUNC, class ... ARGS>
+    ThreadContextPtr<RET>
+    postFirst2(FUNC&& func, ARGS&&... args);
     
     /// @brief Post the first coroutine in a continuation chain to run asynchronously on a specific queue (thread).
     /// @tparam RET Type of future returned by this coroutine.
@@ -117,6 +133,11 @@ public:
     ThreadContextPtr<RET>
     postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
+    /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
+    template <class RET = int, class FUNC, class ... ARGS>
+    ThreadContextPtr<RET>
+    postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
     /// @brief Post a blocking IO (or long running) task to run asynchronously on the IO thread pool.
     /// @tparam RET Type of future returned by this task.
     /// @tparam FUNC Callable object type. Can be a standalone function, a method, an std::function,
@@ -130,6 +151,11 @@ public:
     template <class RET = int, class FUNC, class ... ARGS>
     ThreadFuturePtr<RET>
     postAsyncIo(FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
+    template <class RET = int, class FUNC, class ... ARGS>
+    ThreadFuturePtr<RET>
+    postAsyncIo2(FUNC&& func, ARGS&&... args);
     
     /// @brief Post a blocking IO (or long running) task to run asynchronously on a specific thread in the IO thread pool.
     /// @tparam RET Type of future returned by this task.
@@ -148,6 +174,11 @@ public:
     template <class RET = int, class FUNC, class ... ARGS>
     ThreadFuturePtr<RET>
     postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
+    template <class RET = int, class FUNC, class ... ARGS>
+    ThreadFuturePtr<RET>
+    postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     /// @brief Applies the given unary function to all the elements in the range [first,last).
     ///        This function runs in parallel.
@@ -335,13 +366,28 @@ private:
     postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
     
     template <class RET, class FUNC, class ... ARGS>
+    ThreadContextPtr<RET>
+    postImpl2(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
+    
+    template <class RET, class FUNC, class ... ARGS>
     ThreadFuturePtr<RET>
     postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
+    template <class RET, class FUNC, class ... ARGS>
+    ThreadFuturePtr<RET>
+    postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    
+    struct DrainGuard
+    {
+        DrainGuard(std::atomic_bool& drain) : _drain(drain) { _drain = true; }
+        ~DrainGuard() { _drain = false; }
+        std::atomic_bool& _drain;
+    };
+    
     //Members
     DispatcherCore              _dispatcher;
-    bool                        _drain;
-    std::atomic_flag            _terminated;
+    std::atomic_bool            _drain;
+    std::atomic_bool            _terminated;
 };
 
 using TaskDispatcher = Dispatcher; //alias

--- a/quantum/quantum_dispatcher_core.h
+++ b/quantum/quantum_dispatcher_core.h
@@ -94,7 +94,7 @@ private:
     std::vector<IoQueue>      _sharedIoQueues; //shared IO task queues (hold tasks posted to 'Any' IO queue)
     std::vector<IoQueue>      _ioQueues;       //dedicated IO task queues
     bool                      _loadBalanceSharedIoQueues; //tasks posted to 'Any' IO queue are load balanced
-    std::atomic_flag          _terminated;
+    std::atomic_bool          _terminated;
     std::pair<int, int>       _coroQueueIdRangeForAny; // range of coroutine queueIds covered by 'Any' 
 };
 

--- a/quantum/quantum_io_queue.h
+++ b/quantum/quantum_io_queue.h
@@ -40,7 +40,7 @@ namespace quantum {
 class IoQueue : public IQueue
 {
 public:
-    using TaskList = std::list<IoTask::Ptr, QueueListAllocator>;
+    using TaskList = std::list<IoTask::Ptr, ContiguousPoolManager<IoTask::Ptr>>;
     using TaskListIter = TaskList::iterator;
     
     IoQueue();
@@ -103,7 +103,7 @@ private:
     std::atomic_bool                _isEmpty;
     std::atomic_bool                _isInterrupted;
     std::atomic_bool                _isIdle;
-    std::atomic_flag                _terminated;
+    std::atomic_bool                _terminated;
     QueueStatistics                 _stats;
 };
 

--- a/quantum/quantum_io_task.h
+++ b/quantum/quantum_io_task.h
@@ -39,11 +39,14 @@ public:
     
     template <class RET, class FUNC, class ... ARGS>
     IoTask(std::shared_ptr<Promise<RET>> promise,
+           int queueId,
+           bool isHighPriority,
            FUNC&& func,
            ARGS&&... args);
     
     template <class RET, class FUNC, class ... ARGS>
-    IoTask(std::shared_ptr<Promise<RET>> promise,
+    IoTask(Void,
+           std::shared_ptr<Promise<RET>> promise,
            int queueId,
            bool isHighPriority,
            FUNC&& func,
@@ -77,7 +80,7 @@ public:
     
 private:
     Function<int()>         _func;      //the current runnable io function
-    std::atomic_flag        _terminated;
+    std::atomic_bool        _terminated;
     int                     _queueId;
     bool                    _isHighPriority;
 };

--- a/quantum/quantum_promise.h
+++ b/quantum/quantum_promise.h
@@ -82,7 +82,7 @@ public:
     
 private:
     std::shared_ptr<SharedState<T>> _sharedState;
-    std::atomic_flag                _terminated;
+    std::atomic_bool                _terminated;
 };
 
 template <class T>

--- a/quantum/quantum_stack_allocator.h
+++ b/quantum/quantum_stack_allocator.h
@@ -41,6 +41,7 @@ struct StackAllocator : public ContiguousPoolManager<T>
     typedef value_type&             reference;
     typedef const value_type&       const_reference;
     typedef size_t                  size_type;
+    typedef uint16_t                index_type;
     typedef std::ptrdiff_t          difference_type;
     typedef std::false_type         propagate_on_container_move_assignment;
     typedef std::false_type         propagate_on_container_copy_assignment;
@@ -61,23 +62,33 @@ struct StackAllocator : public ContiguousPoolManager<T>
     {}
     StackAllocator(const this_type&) : StackAllocator()
     {}
-    StackAllocator& operator=(const this_type&)
+    StackAllocator(this_type&&) : StackAllocator()
     {}
-    static StackAllocator select_on_container_copy_construction(const StackAllocator&) {
-        return StackAllocator();
-    }
+    StackAllocator& operator=(const this_type&) = delete;
+    StackAllocator& operator=(this_type&&) = delete;
+    
+    // Rebound types
     template <typename U>
     StackAllocator(const StackAllocator<U,SIZE>&) : StackAllocator()
     {}
     template <typename U>
-    StackAllocator& operator=(const StackAllocator<U,SIZE>&)
+    StackAllocator(StackAllocator<U,SIZE>&&) : StackAllocator()
     {}
-    bool operator==(const this_type&) const {
-        return false;
+    template <typename U>
+    StackAllocator& operator=(const StackAllocator<U,SIZE>&) = delete;
+    template <typename U>
+    StackAllocator& operator=(StackAllocator<U,SIZE>&&) = delete;
+    
+    static StackAllocator select_on_container_copy_construction(const StackAllocator&) {
+        return StackAllocator();
     }
-    bool operator!=(const this_type&) const {
-        return true;
+    bool operator==(const this_type& other) const {
+        return this == &other;
     }
+    bool operator!=(const this_type& other) const {
+        return !operator==(other);
+    }
+    index_type size() const { return SIZE; }
     
 private:
     //------------------------------- Members ----------------------------------

--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -46,12 +46,15 @@ public:
     
     template <class RET, class FUNC, class ... ARGS>
     Task(std::shared_ptr<Context<RET>> ctx,
+         int queueId,
+         bool isHighPriority,
          ITask::Type type,
          FUNC&& func,
          ARGS&&... args);
     
     template <class RET, class FUNC, class ... ARGS>
-    Task(std::shared_ptr<Context<RET>> ctx,
+    Task(Void,
+         std::shared_ptr<Context<RET>> ctx,
          int queueId,
          bool isHighPriority,
          ITask::Type type,
@@ -104,7 +107,7 @@ private:
     ITaskContinuation::Ptr      _next; //Task scheduled to run after current completes.
     ITaskContinuation::WeakPtr  _prev; //Previous task in the chain
     ITask::Type                 _type;
-    std::atomic_flag            _terminated;
+    std::atomic_bool            _terminated;
 };
 
 using TaskPtr = Task::Ptr;

--- a/quantum/quantum_task_queue.h
+++ b/quantum/quantum_task_queue.h
@@ -99,7 +99,7 @@ private:
     std::atomic_bool                    _isEmpty;
     std::atomic_bool                    _isInterrupted;
     std::atomic_bool                    _isIdle;
-    std::atomic_flag                    _terminated;
+    std::atomic_bool                    _terminated;
     bool                                _isAdvanced;
     QueueStatistics                     _stats;
 };

--- a/quantum/util/impl/quantum_future_joiner_impl.h
+++ b/quantum/util/impl/quantum_future_joiner_impl.h
@@ -91,7 +91,7 @@ FutureJoiner<T>::join(CoroContextTag, DISPATCHER& dispatcher, std::vector<typena
 {
 #if (__cplusplus == 201103L)
     std::shared_ptr<std::vector<typename FUTURE<T>::Ptr>> containerPtr(new std::vector<typename FUTURE<T>::Ptr>(std::move(futures)));
-    return dispatcher.template post<std::vector<T>>([containerPtr](CoroContextPtr<std::vector<T>> ctx)
+    return dispatcher.template post2<std::vector<T>>([containerPtr](VoidContextPtr ctx)->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(containerPtr->size());
@@ -99,10 +99,10 @@ FutureJoiner<T>::join(CoroContextTag, DISPATCHER& dispatcher, std::vector<typena
         {
             result.emplace_back(f->get(ctx));
         }
-        return ctx->set(std::move(result));
+        return result;
     });
 #else
-    return dispatcher.template post<std::vector<T>>([container{std::move(futures)}](CoroContextPtr<std::vector<T>> ctx)
+    return dispatcher.template post2<std::vector<T>>([container{std::move(futures)}](VoidContextPtr ctx)->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(container.size());
@@ -110,7 +110,7 @@ FutureJoiner<T>::join(CoroContextTag, DISPATCHER& dispatcher, std::vector<typena
         {
             result.emplace_back(f->get(ctx));
         }
-        return ctx->set(std::move(result));
+        return result;
     });
 #endif
 }

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -46,27 +46,27 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::Sequencer(Dispatcher& dispatc
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     const SequenceKey& sequenceKey,
     FUNC&& func,
     ARGS&&... args)
 {
-    _dispatcher.post<Void>(_controllerQueueId,
-                          false,
-                          singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
-                          nullptr,
-                          (int)IQueue::QueueId::Any,
-                          false,
-                          *this,
-                          SequenceKey(sequenceKey),
-                          std::forward<FUNC>(func),
-                          std::forward<ARGS>(args)...);
+    _dispatcher.post2<int>(_controllerQueueId,
+                           false,
+                           singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                           nullptr,
+                           (int)IQueue::QueueId::Any,
+                           false,
+                           *this,
+                           SequenceKey(sequenceKey),
+                           std::forward<FUNC>(func),
+                           std::forward<ARGS>(args)...);
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     void* opaque,
     int queueId,
     bool isHighPriority,
@@ -79,27 +79,27 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
         throw std::runtime_error("Invalid IO queue id");
     }
 
-    _dispatcher.post<Void>(_controllerQueueId,
-                          false,
-                          singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
-                          std::move(opaque),
-                          std::move(queueId),
-                          std::move(isHighPriority),
-                          *this,
-                          SequenceKey(sequenceKey),
-                          std::forward<FUNC>(func),
-                          std::forward<ARGS>(args)...);
+    _dispatcher.post2<int>(_controllerQueueId,
+                           false,
+                           singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                           std::move(opaque),
+                           std::move(queueId),
+                           std::move(isHighPriority),
+                           *this,
+                           SequenceKey(sequenceKey),
+                           std::forward<FUNC>(func),
+                           std::forward<ARGS>(args)...);
 }
  
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     const std::vector<SequenceKey>& sequenceKeys,
     FUNC&& func,
     ARGS&&... args)
 {
-    _dispatcher.post<Void>(_controllerQueueId,
+    _dispatcher.post2<int>(_controllerQueueId,
                           false,
                           multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
                           nullptr,
@@ -114,7 +114,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     void* opaque,
     int queueId,
     bool isHighPriority,
@@ -126,7 +126,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post<Void>(_controllerQueueId,
+    _dispatcher.post2<int>(_controllerQueueId,
                           false,
                           multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
                           std::move(opaque),
@@ -141,9 +141,9 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::post(
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(FUNC&& func, ARGS&&... args)
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(FUNC&& func, ARGS&&... args)
 {
-    _dispatcher.post<Void>(_controllerQueueId,
+    _dispatcher.post2<int>(_controllerQueueId,
                           false,
                           universalTaskScheduler<FUNC, ARGS...>,
                           nullptr,
@@ -157,7 +157,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(FUNC&& func, ARGS&&..
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 template <class FUNC, class ... ARGS>
 void
-Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(
+Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(
     void* opaque,
     int queueId,
     bool isHighPriority,
@@ -168,7 +168,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::postAll(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post<Void>(_controllerQueueId,
+    _dispatcher.post2<int>(_controllerQueueId,
                           false,
                           universalTaskScheduler<FUNC, ARGS...>,
                           std::move(opaque),

--- a/quantum/util/quantum_sequencer.h
+++ b/quantum/util/quantum_sequencer.h
@@ -51,7 +51,7 @@ public:
     /// @param[in] configuration the configuration object
     Sequencer(Dispatcher& dispatcher, const Configuration& configuration = Configuration());
 
-    /// @brief Post a coroutine to run asynchronously.
+    /// @brief Enqueue a coroutine to run asynchronously.
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine
     ///          associated with the same 'sequenceKey' completes. If there are none, it will run immediately.
     ///          (@see Dispatcher::post for more details).
@@ -68,9 +68,9 @@ public:
     ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
-    post(const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
+    enqueue(const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
 
-    /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
+    /// @brief Enqueue a coroutine to run asynchronously on a specific queue (thread).
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine
     ///          associated with the same 'sequenceKey' completes. If there are none, it will run immediately.
     ///          (@see Dispatcher::post for more details).
@@ -97,9 +97,9 @@ public:
     ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
-    post(void* opaque, int queueId, bool isHighPriority, const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
+    enqueue(void* opaque, int queueId, bool isHighPriority, const SequenceKey& sequenceKey, FUNC&& func, ARGS&&... args);
 
-    /// @brief Post a coroutine to run asynchronously.
+    /// @brief Enqueue a coroutine to run asynchronously.
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine(s)
     ///          associated with all the 'sequenceKeys' complete. If there are none, then it will run immediately.
     ///          (@see Dispatcher::post for more details).
@@ -116,9 +116,9 @@ public:
     ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
-    post(const std::vector<SequenceKey>& sequenceKeys, FUNC&& func, ARGS&&... args);
+    enqueue(const std::vector<SequenceKey>& sequenceKeys, FUNC&& func, ARGS&&... args);
 
-    /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
+    /// @brief Enqueue a coroutine to run asynchronously on a specific queue (thread).
     /// @details This method will post the coroutine on any thread available and will run when the previous coroutine(s)
     ///          associated with all the 'sequenceKeys' complete. If there are none, then it will run immediately.
     ///          (@see Dispatcher::post for more details).
@@ -145,14 +145,14 @@ public:
     ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
-    post(void* opaque,
-         int queueId,
-         bool isHighPriority,
-         const std::vector<SequenceKey>& sequenceKeys,
-         FUNC&& func,
-         ARGS&&... args);
+    enqueue(void* opaque,
+            int queueId,
+            bool isHighPriority,
+            const std::vector<SequenceKey>& sequenceKeys,
+            FUNC&& func,
+            ARGS&&... args);
 
-    /// @brief Post a coroutine to run asynchronously.
+    /// @brief Enqueue a coroutine to run asynchronously after all keys have run.
     /// @details This method will post the coroutine on any thread available. The posted task is assumed to be associated
     ///          with the entire universe of sequenceKeys already running or pending, which means that it will wait
     ///          until all tasks complete. This task can be considered as having a 'universal' key.
@@ -168,9 +168,9 @@ public:
     ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
-    postAll(FUNC&& func, ARGS&&... args);
+    enqueueAll(FUNC&& func, ARGS&&... args);
 
-    /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
+    /// @brief Enqueue a coroutine to run asynchronously on a specific queue (thread), after all keys have run.
     /// @details This method will post the coroutine on any thread available. The posted task is assumed to be associated
     ///          with the entire universe of sequenceKeys already running or pending, which means that it will wait
     ///          until all tasks complete. This task can be considered as having a 'universal' key.
@@ -196,7 +196,7 @@ public:
     ///          However it should *not* be set and this will result in undefined behavior.
     template <class FUNC, class ... ARGS>
     void
-    postAll(void* opaque, int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    enqueueAll(void* opaque, int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
 
     /// @brief Trims the sequence keys not used by the sequencer anymore.
     /// @details It's recommended to call this function periodically to clean up state sequence keys.

--- a/quantum/util/quantum_util.h
+++ b/quantum/util/quantum_util.h
@@ -49,8 +49,16 @@ struct Util
     bindCaller(std::shared_ptr<Context<RET>> ctx, FUNC&& func0, ARGS&& ...args0);
     
     template<class RET, class FUNC, class ...ARGS>
+    static Function<int(Traits::Yield&)>
+    bindCaller2(std::shared_ptr<Context<RET>> ctx, FUNC&& func0, ARGS&& ...args0);
+    
+    template<class RET, class FUNC, class ...ARGS>
     static Function<int()>
     bindIoCaller(std::shared_ptr<Promise<RET>> promise, FUNC&& func0, ARGS&& ...args0);
+    
+    template<class RET, class FUNC, class ...ARGS>
+    static Function<int()>
+    bindIoCaller2(std::shared_ptr<Promise<RET>> promise, FUNC&& func0, ARGS&& ...args0);
     
     template <typename RET>
     static VoidContextPtr makeVoidContext(CoroContextPtr<RET> ctx);
@@ -59,13 +67,13 @@ struct Util
     //                                      ForEach
     //------------------------------------------------------------------------------------------
     template <class RET, class INPUT_IT, class FUNC>
-    static int forEachCoro(CoroContextPtr<std::vector<RET>> ctx,
+    static std::vector<RET> forEachCoro(VoidContextPtr ctx,
                            INPUT_IT inputIt,
                            size_t num,
                            FUNC&& func);
     
     template <class RET, class INPUT_IT, class FUNC>
-    static int forEachBatchCoro(CoroContextPtr<std::vector<std::vector<RET>>> ctx,
+    static std::vector<std::vector<RET>> forEachBatchCoro(VoidContextPtr ctx,
                                 INPUT_IT inputIt,
                                 size_t num,
                                 FUNC&& func,
@@ -78,7 +86,8 @@ struct Util
               class MAPPED_TYPE,
               class REDUCED_TYPE,
               class INPUT_IT>
-    static int mapReduceCoro(CoroContextPtr<std::map<KEY, REDUCED_TYPE>> ctx,
+    static std::map<KEY, REDUCED_TYPE>
+    mapReduceCoro(VoidContextPtr ctx,
                              INPUT_IT inputIt,
                              size_t num,
                              const Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>& mapper,
@@ -88,7 +97,7 @@ struct Util
               class MAPPED_TYPE,
               class REDUCED_TYPE,
               class INPUT_IT>
-    static int mapReduceBatchCoro(CoroContextPtr<std::map<KEY, REDUCED_TYPE>> ctx,
+    static std::map<KEY, REDUCED_TYPE> mapReduceBatchCoro(VoidContextPtr ctx,
                                   INPUT_IT inputIt,
                                   size_t num,
                                   const Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>& mapper,


### PR DESCRIPTION
###Description
* Adding support for alternative v2 API implementation which supports a simpler coroutine signature.
* Changed `Sequencer::post()` to `Sequencer::enqueue()` since `Sequencer::post()` is now calling `Dispatcher::post2()` underneath and it would be too confusing. This is a minor API break but since `Sequencer` is a relatively new class, we hope the usage is still low.
* Small internal changes to `ContiguousPoolManager` class to properly resize non-owned buffer when rebinding to a different (larger) type.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>