### PR TITLE
Renamed ReadWriteSpinlock to ReadWriteSpinLock

### DIFF
--- a/quantum/impl/quantum_read_write_spinlock_impl.h
+++ b/quantum/impl/quantum_read_write_spinlock_impl.h
@@ -23,7 +23,7 @@ namespace Bloomberg {
 namespace quantum {
 
 inline
-void ReadWriteSpinlock::lockRead()
+void ReadWriteSpinLock::lockRead()
 {
     int oldValue = 0;
     int newValue = 1;
@@ -42,7 +42,7 @@ void ReadWriteSpinlock::lockRead()
 }
 
 inline
-void ReadWriteSpinlock::lockWrite()
+void ReadWriteSpinLock::lockWrite()
 {
     int i{0};
     while (!_count.compare_exchange_weak(i, -1, std::memory_order_acq_rel)) {
@@ -51,7 +51,7 @@ void ReadWriteSpinlock::lockWrite()
 }
 
 inline
-bool ReadWriteSpinlock::tryLockRead()
+bool ReadWriteSpinLock::tryLockRead()
 {
     int oldValue = 0;
     int newValue = 1;
@@ -70,51 +70,51 @@ bool ReadWriteSpinlock::tryLockRead()
 }
 
 inline
-bool ReadWriteSpinlock::tryLockWrite()
+bool ReadWriteSpinLock::tryLockWrite()
 {
     int i{0};
     return _count.compare_exchange_strong(i, -1, std::memory_order_acq_rel);
 }
 
 inline
-void ReadWriteSpinlock::unlockRead()
+void ReadWriteSpinLock::unlockRead()
 {
     _count.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 inline
-void ReadWriteSpinlock::unlockWrite()
+void ReadWriteSpinLock::unlockWrite()
 {
     _count.fetch_add(1, std::memory_order_acq_rel);
 }
 
 inline
-bool ReadWriteSpinlock::isLocked()
+bool ReadWriteSpinLock::isLocked()
 {
     return _count.load(std::memory_order_acquire) != 0;
 }
 
 inline
-bool ReadWriteSpinlock::isReadLocked()
+bool ReadWriteSpinLock::isReadLocked()
 {
     return _count.load(std::memory_order_acquire) > 0;
 }
 
 inline
-bool ReadWriteSpinlock::isWriteLocked()
+bool ReadWriteSpinLock::isWriteLocked()
 {
     return _count.load(std::memory_order_acquire) == -1;
 }
 
 inline
-int ReadWriteSpinlock::numReaders() const
+int ReadWriteSpinLock::numReaders() const
 {
     int num = _count.load(std::memory_order_acquire);
     return num == -1 ? 0 : num;
 }
 
 inline
-ReadWriteSpinlock::ReadGuard::ReadGuard(ReadWriteSpinlock& lock) :
+ReadWriteSpinLock::ReadGuard::ReadGuard(ReadWriteSpinLock& lock) :
     _spinlock(lock),
     _ownsLock(true)
 {
@@ -122,14 +122,14 @@ ReadWriteSpinlock::ReadGuard::ReadGuard(ReadWriteSpinlock& lock) :
 }
 
 inline
-ReadWriteSpinlock::ReadGuard::ReadGuard(ReadWriteSpinlock& lock, ReadWriteSpinlock::TryToLock) :
+ReadWriteSpinLock::ReadGuard::ReadGuard(ReadWriteSpinLock& lock, ReadWriteSpinLock::TryToLock) :
     _spinlock(lock),
     _ownsLock(_spinlock.tryLockRead())
 {
 }
 
 inline
-ReadWriteSpinlock::ReadGuard::~ReadGuard()
+ReadWriteSpinLock::ReadGuard::~ReadGuard()
 {
     if (_ownsLock) {
         _spinlock.unlockRead();
@@ -137,7 +137,7 @@ ReadWriteSpinlock::ReadGuard::~ReadGuard()
 }
 
 inline
-void ReadWriteSpinlock::ReadGuard::lock()
+void ReadWriteSpinLock::ReadGuard::lock()
 {
     if (!_ownsLock) {
         _spinlock.lockRead();
@@ -146,7 +146,7 @@ void ReadWriteSpinlock::ReadGuard::lock()
 }
 
 inline
-bool ReadWriteSpinlock::ReadGuard::tryLock()
+bool ReadWriteSpinLock::ReadGuard::tryLock()
 {
     if (!_ownsLock) {
         _ownsLock = _spinlock.tryLockRead();
@@ -155,13 +155,13 @@ bool ReadWriteSpinlock::ReadGuard::tryLock()
 }
 
 inline
-bool ReadWriteSpinlock::ReadGuard::ownsLock() const
+bool ReadWriteSpinLock::ReadGuard::ownsLock() const
 {
     return _ownsLock;
 }
 
 inline
-ReadWriteSpinlock::WriteGuard::WriteGuard(ReadWriteSpinlock& lock) :
+ReadWriteSpinLock::WriteGuard::WriteGuard(ReadWriteSpinLock& lock) :
     _spinlock(lock),
     _ownsLock(true)
 {
@@ -169,14 +169,14 @@ ReadWriteSpinlock::WriteGuard::WriteGuard(ReadWriteSpinlock& lock) :
 }
 
 inline
-ReadWriteSpinlock::WriteGuard::WriteGuard(ReadWriteSpinlock& lock, ReadWriteSpinlock::TryToLock) :
+ReadWriteSpinLock::WriteGuard::WriteGuard(ReadWriteSpinLock& lock, ReadWriteSpinLock::TryToLock) :
     _spinlock(lock),
     _ownsLock(_spinlock.tryLockWrite())
 {
 }
 
 inline
-ReadWriteSpinlock::WriteGuard::~WriteGuard()
+ReadWriteSpinLock::WriteGuard::~WriteGuard()
 {
     if (_ownsLock) {
         _spinlock.unlockWrite();
@@ -184,7 +184,7 @@ ReadWriteSpinlock::WriteGuard::~WriteGuard()
 }
 
 inline
-void ReadWriteSpinlock::WriteGuard::lock()
+void ReadWriteSpinLock::WriteGuard::lock()
 {
     if (!_ownsLock) {
         _spinlock.lockWrite();
@@ -193,7 +193,7 @@ void ReadWriteSpinlock::WriteGuard::lock()
 }
 
 inline
-bool ReadWriteSpinlock::WriteGuard::tryLock()
+bool ReadWriteSpinLock::WriteGuard::tryLock()
 {
     if (!_ownsLock) {
         _ownsLock = _spinlock.tryLockWrite();
@@ -202,7 +202,7 @@ bool ReadWriteSpinlock::WriteGuard::tryLock()
 }
 
 inline
-bool ReadWriteSpinlock::WriteGuard::ownsLock() const
+bool ReadWriteSpinLock::WriteGuard::ownsLock() const
 {
     return _ownsLock;
 }

--- a/quantum/quantum_read_write_spinlock.h
+++ b/quantum/quantum_read_write_spinlock.h
@@ -22,25 +22,25 @@
 namespace Bloomberg {
 namespace quantum {
 
-class ReadWriteSpinlock
+class ReadWriteSpinLock
 {
 public:
     using TryToLock = std::try_to_lock_t;
     
     /// @brief Constructor. The object is in the unlocked state.
-    ReadWriteSpinlock() = default;
+    ReadWriteSpinLock() = default;
     
     /// @brief Copy constructor.
-    ReadWriteSpinlock(const ReadWriteSpinlock&) = delete;
+    ReadWriteSpinLock(const ReadWriteSpinLock&) = delete;
     
     /// @brief Move constructor.
-    ReadWriteSpinlock(ReadWriteSpinlock&&) = default;
+    ReadWriteSpinLock(ReadWriteSpinLock&&) = default;
     
     /// @brief Copy assignment operator.
-    ReadWriteSpinlock& operator=(const ReadWriteSpinlock&) = delete;
+    ReadWriteSpinLock& operator=(const ReadWriteSpinLock&) = delete;
     
     /// @brief Move assignment operator.
-    ReadWriteSpinlock& operator=(ReadWriteSpinlock&&) = default;
+    ReadWriteSpinLock& operator=(ReadWriteSpinLock&&) = default;
     
     /// @brief Lock this object as a reader (shared with other readers)
     void lockRead();
@@ -84,14 +84,14 @@ public:
     {
     public:
         /// @brief Construct this object and lock the passed-in spinlock as a reader.
-        /// @param[in] lock ReadWriteSpinlock which protects a scope during the lifetime of the Guard.
+        /// @param[in] lock ReadWriteSpinLock which protects a scope during the lifetime of the Guard.
         /// @note Blocks the current thread until the spinlock is acquired.
-        explicit ReadGuard(ReadWriteSpinlock& lock);
+        explicit ReadGuard(ReadWriteSpinLock& lock);
         
         /// @brief Construct this object and tries to lock the passed-in spinlock as a reader.
-        /// @param[in] lock ReadWriteSpinlock which protects a scope during the lifetime of the Guard.
+        /// @param[in] lock ReadWriteSpinLock which protects a scope during the lifetime of the Guard.
         /// @note Attempts to lock the spinlock. Does not block.
-        ReadGuard(ReadWriteSpinlock& lock, ReadWriteSpinlock::TryToLock);
+        ReadGuard(ReadWriteSpinLock& lock, ReadWriteSpinLock::TryToLock);
         
         /// @brief Destroy this object and unlock the underlying spinlock.
         ~ReadGuard();
@@ -109,7 +109,7 @@ public:
         /// @return True if ownership is acquired.
         bool ownsLock() const;
     private:
-        ReadWriteSpinlock&	_spinlock;
+        ReadWriteSpinLock&	_spinlock;
         bool                _ownsLock;
     };
     
@@ -117,14 +117,14 @@ public:
     {
     public:
         /// @brief Construct this object and lock the passed-in spinlock as a writer.
-        /// @param[in] lock ReadWriteSpinlock which protects a scope during the lifetime of the Guard.
+        /// @param[in] lock ReadWriteSpinLock which protects a scope during the lifetime of the Guard.
         /// @note Blocks the current thread until the spinlock is acquired.
-        explicit WriteGuard(ReadWriteSpinlock& lock);
+        explicit WriteGuard(ReadWriteSpinLock& lock);
         
         /// @brief Construct this object and tries to lock the passed-in spinlock as a writer.
-        /// @param[in] lock ReadWriteSpinlock which protects a scope during the lifetime of the Guard.
+        /// @param[in] lock ReadWriteSpinLock which protects a scope during the lifetime of the Guard.
         /// @note Attempts to lock the spinlock. Does not block.
-        WriteGuard(ReadWriteSpinlock& lock, ReadWriteSpinlock::TryToLock);
+        WriteGuard(ReadWriteSpinLock& lock, ReadWriteSpinLock::TryToLock);
         
         /// @brief Destroy this object and unlock the underlying spinlock.
         ~WriteGuard();
@@ -142,7 +142,7 @@ public:
         /// @return True if ownership is acquired.
         bool ownsLock() const;
     private:
-        ReadWriteSpinlock&	_spinlock;
+        ReadWriteSpinLock&	_spinlock;
         bool                _ownsLock;
     };
     

--- a/tests/quantum_spinlocks_tests.cpp
+++ b/tests/quantum_spinlocks_tests.cpp
@@ -41,9 +41,9 @@ TEST(Spinlock, Spinlock)
     EXPECT_EQ(0, val);
 }
 
-TEST(ReadWriteSpinlock, LockReadMultipleTimes)
+TEST(ReadWriteSpinLock, LockReadMultipleTimes)
 {
-    ReadWriteSpinlock spin;
+    ReadWriteSpinLock spin;
     EXPECT_EQ(0, spin.numReaders());
     EXPECT_FALSE(spin.isLocked());
     spin.lockRead();
@@ -58,35 +58,35 @@ TEST(ReadWriteSpinlock, LockReadMultipleTimes)
     EXPECT_FALSE(spin.isLocked());
 }
 
-TEST(ReadWriteSpinlock, LockReadAndWrite)
+TEST(ReadWriteSpinLock, LockReadAndWrite)
 {
     int num = 1000000;
     int val = 0;
-    ReadWriteSpinlock spin;
+    ReadWriteSpinLock spin;
     std::thread t1([&, num]() mutable {
         while (num--) {
-            ReadWriteSpinlock::ReadGuard guard(spin);
+            ReadWriteSpinLock::ReadGuard guard(spin);
         }
     });
     std::thread t2([&, num]() mutable {
         while (num--) {
-            ReadWriteSpinlock::ReadGuard guard(spin);
+            ReadWriteSpinLock::ReadGuard guard(spin);
         }
     });
     std::thread t3([&, num]() mutable {
         while (num--) {
-            ReadWriteSpinlock::ReadGuard guard(spin);
+            ReadWriteSpinLock::ReadGuard guard(spin);
         }
     });
     std::thread t4([&, num]() mutable {
         while (num--) {
-            ReadWriteSpinlock::WriteGuard guard(spin);
+            ReadWriteSpinLock::WriteGuard guard(spin);
             ++val;
         }
     });
     std::thread t5([&, num]() mutable {
         while (num--) {
-            ReadWriteSpinlock::WriteGuard guard(spin);
+            ReadWriteSpinLock::WriteGuard guard(spin);
             --val;
         }
     });
@@ -98,42 +98,42 @@ TEST(ReadWriteSpinlock, LockReadAndWrite)
     EXPECT_EQ(0, val);
 }
 
-TEST(ReadWriteSpinlock, LockReadAndWriteList)
+TEST(ReadWriteSpinLock, LockReadAndWriteList)
 {
     int num = 1000000;
     std::list<int> val;
-    ReadWriteSpinlock spin;
+    ReadWriteSpinLock spin;
     bool exit = false;
     std::thread t1([&]() mutable {
         while (!exit) {
-            ReadWriteSpinlock::ReadGuard guard(spin);
+            ReadWriteSpinLock::ReadGuard guard(spin);
             auto it = val.rbegin();
             if (it != val.rend()) --it;
         }
     });
     std::thread t2([&]() mutable {
         while (!exit) {
-            ReadWriteSpinlock::ReadGuard guard(spin);
+            ReadWriteSpinLock::ReadGuard guard(spin);
             auto it = val.rbegin();
             if (it != val.rend()) --it;
         }
     });
     std::thread t3([&]() mutable {
         while (!exit) {
-            ReadWriteSpinlock::ReadGuard guard(spin);
+            ReadWriteSpinLock::ReadGuard guard(spin);
             auto it = val.rbegin();
             if (it != val.rend()) --it;
         }
     });
     std::thread t4([&, num]() mutable {
         while (num--) {
-            ReadWriteSpinlock::WriteGuard guard(spin);
+            ReadWriteSpinLock::WriteGuard guard(spin);
             val.push_back(1);
         }
     });
     std::thread t5([&, num]() mutable {
         while (num) {
-            ReadWriteSpinlock::WriteGuard guard(spin);
+            ReadWriteSpinLock::WriteGuard guard(spin);
             if (!val.empty()) {
                 val.pop_back();
                 --num;


### PR DESCRIPTION
Renamed `ReadWriteSpinlock` to `ReadWriteSpinLock` for consistency purposes with `SpinLock` class.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>