### PR TITLE
Fixed redefinition of reinterpret_pointer_cast when compiling with c++17

### DIFF
--- a/quantum/impl/quantum_stl_impl.h
+++ b/quantum/impl/quantum_stl_impl.h
@@ -65,7 +65,7 @@ namespace std {
     template<typename... _Types>
     using index_sequence_for = make_index_sequence<sizeof...(_Types)>;
 #endif
-#if (__cplusplus <= 201703L)
+#if (__cplusplus < 201703L)
     template<class T, class U>
     std::shared_ptr<T> reinterpret_pointer_cast(const std::shared_ptr<U>& r) noexcept
     {


### PR DESCRIPTION
Signed-off-by: Alex Damian <adamian@bloomberg.net>