### PR TITLE
Using steady_clock for all time interval measurements. 

### DIFF
--- a/quantum.pc.in
+++ b/quantum.pc.in
@@ -8,6 +8,6 @@ Name: quantum
 Url: https://github.com/bloomberg/quantum
 Description: C++ coroutine library using Boost.Coroutine2
 Version: @QUANTUM_VERSION@
-Requires.private: boost_context >= 1.61
+Requires.private: boost-context >= 1.61
 Libs: -L${libdir} -L${sharedlibdir}
 Cflags: -I${includedir}

--- a/quantum/impl/quantum_condition_variable_impl.h
+++ b/quantum/impl/quantum_condition_variable_impl.h
@@ -200,7 +200,7 @@ bool ConditionVariable::waitForImpl(ICoroSync::Ptr sync,
     }
     //========= UNLOCKED SCOPE =========
     Mutex::ReverseGuard unlock(sync, mutex);
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     auto elapsed = std::chrono::duration<REP, PERIOD>::zero();
     bool timeout = false;
     
@@ -209,7 +209,7 @@ bool ConditionVariable::waitForImpl(ICoroSync::Ptr sync,
     {
         yield(sync);
         elapsed = std::chrono::duration_cast<std::chrono::duration<REP, PERIOD>>
-                  (std::chrono::high_resolution_clock::now() - start);
+                  (std::chrono::steady_clock::now() - start);
         if (elapsed >= time)
         {
             timeout = true;

--- a/quantum/impl/quantum_context_impl.h
+++ b/quantum/impl/quantum_context_impl.h
@@ -638,19 +638,14 @@ bool Context<RET>::isSleeping(bool updateTimer)
         if (!updateTimer) {
             return true;
         }
-        auto now = std::chrono::high_resolution_clock::now();
+        auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(now-_sleepTimestamp);
-        if (elapsed >= _sleepDuration) {
-            //expired so we reset all values
-            _sleepDuration = std::chrono::microseconds(0);
-            _sleepTimestamp = std::chrono::high_resolution_clock::time_point{};
-        }
-        else {
-            //reduce duration and save new timestamp
-            _sleepDuration -= elapsed;
-            _sleepTimestamp = now;
+        if (elapsed <= _sleepDuration) {
             return true;
         }
+        // reset value since we have expired
+        _sleepDuration = std::chrono::microseconds::zero();
+        _sleepTimestamp = std::chrono::steady_clock::time_point{};
     }
     return false;
 }
@@ -767,7 +762,7 @@ template <class RET>
 void Context<RET>::sleep(const std::chrono::microseconds& timeUs)
 {
     _sleepDuration = timeUs;
-    _sleepTimestamp = std::chrono::high_resolution_clock::now();
+    _sleepTimestamp = std::chrono::steady_clock::now();
     if (isSleeping()) {
         yield();
     }

--- a/quantum/impl/quantum_dispatcher_impl.h
+++ b/quantum/impl/quantum_dispatcher_impl.h
@@ -324,7 +324,7 @@ void Dispatcher::drain(std::chrono::milliseconds timeout)
 {
     DrainGuard guard(_drain);
     
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     
     //wait until all queues have completed their work
     YieldingThread yield;
@@ -335,7 +335,7 @@ void Dispatcher::drain(std::chrono::milliseconds timeout)
         //check remaining time
         if (timeout != std::chrono::milliseconds::zero())
         {
-            auto present = std::chrono::high_resolution_clock::now();
+            auto present = std::chrono::steady_clock::now();
             if (std::chrono::duration_cast<std::chrono::milliseconds>(present-start) > timeout)
             {
                 //timeout reached

--- a/quantum/quantum_context.h
+++ b/quantum/quantum_context.h
@@ -347,7 +347,7 @@ private:
     std::atomic_int                     _signal;
     Traits::Yield*                      _yield;
     std::chrono::microseconds           _sleepDuration;
-    std::chrono::high_resolution_clock::time_point  _sleepTimestamp;
+    std::chrono::steady_clock::time_point  _sleepTimestamp;
 };
 
 template <class RET>

--- a/tests/quantum_sequencer_tests.cpp
+++ b/tests/quantum_sequencer_tests.cpp
@@ -30,9 +30,9 @@ public: // types
     struct TaskResult
     {
         /// Task start time
-        std::chrono::system_clock::time_point startTime;
+        std::chrono::steady_clock::time_point startTime;
         /// Task end time
-        std::chrono::system_clock::time_point endTime;
+        std::chrono::steady_clock::time_point endTime;
     };
     using TaskResultMap = std::unordered_map<TaskId, TaskResult>;
     using SequenceKeyMap = std::unordered_map<SequenceKey, std::vector<TaskId>>;
@@ -94,14 +94,14 @@ private: // methods
 
     void taskFunc(VoidContextPtr ctx, TaskId id, std::atomic<bool>* blockFlag, std::string error)
     {
-        std::chrono::system_clock::time_point startTime = std::chrono::system_clock::now();
+        std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
         do {
             ctx->sleep(std::chrono::milliseconds(1));
             if (not error.empty())
                 throw std::runtime_error(error);
         }
         while(blockFlag and *blockFlag);
-        std::chrono::system_clock::time_point endTime = std::chrono::system_clock::now();
+        std::chrono::steady_clock::time_point endTime = std::chrono::steady_clock::now();
 
         // update the task map with the time stats
         quantum::Mutex::Guard lock(ctx, _resultMutex);

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -579,9 +579,9 @@ TEST(ExecutionTest, CoroutineSleep)
         return 0;
     });
     
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     ctx->wait(); //block until value is available
-    auto end = std::chrono::high_resolution_clock::now();
+    auto end = std::chrono::steady_clock::now();
     
     //check elapsed time
     size_t elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
@@ -864,9 +864,9 @@ TEST(PromiseTest, FutureTimeout)
         return 0;
     });
     
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     std::future_status status = ctx->waitFor(ms(100)); //block until value is available or 100ms have expired
-    auto end = std::chrono::high_resolution_clock::now();
+    auto end = std::chrono::steady_clock::now();
     
     //check elapsed time
     size_t elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
@@ -882,9 +882,9 @@ TEST(PromiseTest, FutureWithoutTimeout)
         return 0;
     });
     
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     std::future_status status = ctx->waitFor(ms(300)); //block until value is available or 300ms have expired
-    auto end = std::chrono::high_resolution_clock::now();
+    auto end = std::chrono::steady_clock::now();
     
     //check elapsed time
     size_t elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
@@ -902,9 +902,9 @@ TEST(PromiseTest, WaitForAllFutures)
     };
     
     auto ctx = dispatcher.postFirst(func)->then(func)->then(func)->then(func)->end();
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     ctx->waitAll(); //block until value is available or 4x50ms has expired
-    auto end = std::chrono::high_resolution_clock::now();
+    auto end = std::chrono::steady_clock::now();
     
     //check elapsed time
     size_t elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();


### PR DESCRIPTION
**Description**
* Using steady_clock for all time interval measurements. 
* Fixed `boost-context` library name in .pc file.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>