### PR TITLE
Shared any-coro-queue changes

### DIFF
--- a/quantum/impl/quantum_configuration_impl.h
+++ b/quantum/impl/quantum_configuration_impl.h
@@ -137,6 +137,12 @@ void Configuration::setCoroQueueIdRangeForAny(const std::pair<int, int>& coroQue
 }
 
 inline
+void Configuration::setCoroutineSharingForAny(bool sharing)
+{
+     _coroutineSharingForAny = sharing;
+}
+
+inline
 int Configuration::getNumCoroutineThreads() const
 {
     return _numCoroutineThreads;
@@ -184,5 +190,11 @@ const std::pair<int, int>& Configuration::getCoroQueueIdRangeForAny() const
     return  _coroQueueIdRangeForAny;
 }
 
+inline
+bool Configuration::getCoroutineSharingForAny() const
+{
+    return _coroutineSharingForAny;
+}
+    
 }
 }

--- a/quantum/impl/quantum_configuration_impl.h
+++ b/quantum/impl/quantum_configuration_impl.h
@@ -72,6 +72,10 @@ const std::string& Configuration::getJsonSchema()
             "coroQueueIdRangeForAnyHigh": {
                 "type": "number",
                 "default": -1
+            },
+            "coroSharingForAny": {
+                "type": "boolean",
+                "default": false
             }
         },
         "additionalProperties": false,

--- a/quantum/interface/quantum_itask.h
+++ b/quantum/interface/quantum_itask.h
@@ -41,10 +41,14 @@ struct ITask : public ITerminate
     
     enum class RetCode : int
     {
-        Success = 0,
-        Running = std::numeric_limits<int>::max(),
-        Exception = (int)Running-1,
-        NotCallable = (int)Running-2,
+        Success = 0,                                ///< Coroutine finished successfully
+        Running = std::numeric_limits<int>::max(),  ///< Coroutine is still active
+        AlreadyResumed = (int)Running-1,            ///< Coroutine is running on a different thread
+        Exception = (int)Running-2,                 ///< Coroutine ended in an exception
+        NotCallable = (int)Running-3,               ///< Coroutine cannot be called
+        Blocked = (int)Running-4,                   ///< Coroutine is blocked
+        Sleeping = (int)Running-5,                  ///< Coroutine is sleeping
+        Max = (int)Running-10,                      ///< Value of the max reserved return code
     };
     
     ~ITask() = default;

--- a/quantum/quantum_configuration.h
+++ b/quantum/quantum_configuration.h
@@ -86,6 +86,10 @@ public:
     /// @remark if the provided range is empty or invalid, then the default range of
     /// std::pair<int, int>(0, getNumCoroutineThreads()-1) will be used
     void setCoroQueueIdRangeForAny(const std::pair<int, int>& coroQueueIdRangeForAny);
+
+    /// @brief Enables or disables the shared-coro-queue-for-any settings
+    /// @param[in] isSharedCoroQueueForAny sets the shared-coro-queue-for any setting
+    void setCoroutineSharingForAny(bool sharing);
     
     /// @brief Get the number of coroutine threads.
     /// @return The number of threads.
@@ -120,6 +124,10 @@ public:
     /// @return queueIdRange The range of queueIds that IQueue::QueueId::Any covers
     const std::pair<int, int>& getCoroQueueIdRangeForAny() const;
     
+    /// @brief Gets the enablement flag of the shared-coro-queue-for-any
+    /// @return the enablement flag for the feature
+    bool getCoroutineSharingForAny() const;
+    
 private:
     int                         _numCoroutineThreads{-1};
     int                         _numIoThreads{5};
@@ -129,6 +137,7 @@ private:
     BackoffPolicy               _loadBalancePollIntervalBackoffPolicy{BackoffPolicy::Linear};
     size_t                      _loadBalancePollIntervalNumBackoffs{0};
     std::pair<int, int>         _coroQueueIdRangeForAny{-1, -1};
+    bool                        _coroutineSharingForAny{false};
 };
 
 }}

--- a/quantum/quantum_configuration.h
+++ b/quantum/quantum_configuration.h
@@ -89,6 +89,10 @@ public:
 
     /// @brief Enables or disables the shared-coro-queue-for-any settings
     /// @param[in] isSharedCoroQueueForAny sets the shared-coro-queue-for any setting
+    /// @warning When the coroutine sharing feature is enabled, then after each yield 
+    /// (explicit or implicit) a coroutine sent to the Any queue may be executed by
+    /// a different thread. As a result, coroutines using thread-local-storage (e.g., via thread_local),
+    /// will _not_ work as expected.
     void setCoroutineSharingForAny(bool sharing);
     
     /// @brief Get the number of coroutine threads.

--- a/quantum/quantum_dispatcher_core.h
+++ b/quantum/quantum_dispatcher_core.h
@@ -90,12 +90,13 @@ private:
     QueueStatistics ioStats(int queueId);
     
     //Members
-    std::vector<TaskQueue>    _coroQueues;     //coroutine queues
-    std::vector<IoQueue>      _sharedIoQueues; //shared IO task queues (hold tasks posted to 'Any' IO queue)
-    std::vector<IoQueue>      _ioQueues;       //dedicated IO task queues
-    bool                      _loadBalanceSharedIoQueues; //tasks posted to 'Any' IO queue are load balanced
-    std::atomic_bool          _terminated;
-    std::pair<int, int>       _coroQueueIdRangeForAny; // range of coroutine queueIds covered by 'Any' 
+    std::shared_ptr<TaskQueue>  _sharedCoroAnyQueue; // shared coro queue for Any
+    std::vector<TaskQueue>      _coroQueues;     //coroutine queues
+    std::vector<IoQueue>        _sharedIoQueues; //shared IO task queues (hold tasks posted to 'Any' IO queue)
+    std::vector<IoQueue>        _ioQueues;       //dedicated IO task queues
+    bool                        _loadBalanceSharedIoQueues; //tasks posted to 'Any' IO queue are load balanced
+    std::atomic_bool            _terminated;
+    std::pair<int, int>         _coroQueueIdRangeForAny; // range of coroutine queueIds covered by 'Any' 
 };
 
 }}

--- a/quantum/util/impl/quantum_util_impl.h
+++ b/quantum/util/impl/quantum_util_impl.h
@@ -34,7 +34,8 @@ int bindCoro(Traits::Yield& yield,
     try
     {
         ctx->setYieldHandle(yield); //set coroutine yield
-        yield.get() = std::forward<CAPTURE>(capture)();
+        int rc = std::forward<CAPTURE>(capture)();
+        yield.get() = rc;
         return 0;
     }
     catch(const boost::coroutines2::detail::forced_unwind&) {
@@ -69,7 +70,8 @@ int bindCoro2(Traits::Yield& yield,
     try
     {
         ctx->setYieldHandle(yield); //set coroutine yield
-        yield.get() = ctx->set(std::forward<CAPTURE>(capture)());
+        int rc = ctx->set(std::forward<CAPTURE>(capture)());
+        yield.get() = rc;
         return 0;
     }
     catch(const boost::coroutines2::detail::forced_unwind&) {

--- a/quantum/util/impl/quantum_util_impl.h
+++ b/quantum/util/impl/quantum_util_impl.h
@@ -34,6 +34,9 @@ int bindCoro(Traits::Yield& yield,
     try
     {
         ctx->setYieldHandle(yield); //set coroutine yield
+        // the return address of rc must be on the coroutine stack so that it can be properly captured
+        // in the coroutine context. Otherwise when multiple threads run the same coroutine,
+        // the return value will be copied in the wrong location.
         int rc = std::forward<CAPTURE>(capture)();
         yield.get() = rc;
         return 0;
@@ -70,6 +73,9 @@ int bindCoro2(Traits::Yield& yield,
     try
     {
         ctx->setYieldHandle(yield); //set coroutine yield
+        // the return address of rc must be on the coroutine stack so that it can be properly captured
+        // in the coroutine context. Otherwise when multiple threads run the same coroutine,
+        // the return value will be copied in the wrong location.
         int rc = ctx->set(std::forward<CAPTURE>(capture)());
         yield.get() = rc;
         return 0;


### PR DESCRIPTION
Signed-off-by: Denis Mindolin <dmindolin1@bloomberg.net>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
Introducing the shared-any-coro-queue mode. When this feature is enabled, Dispatcher creates a dedicated Queue::QueueId::Any queue and a thread for processing tasks enqueued into it. All coroutine tasks enqueued with queueId = Queue::QueueId::Any will be pushed to that queue. Also each thread in the coroQueueIdRangeForAny range registers itself as a 'helper' for the Queue::QueueId::Any queue and executes tasks  from the Queue::QueueId::Any as well as tasks from its own queue.

**Testing performed**
Ran the existing tests and added a performance test for this mode.

**Additional context**
Add any other context about your contribution here.
