### PR TITLE
Named threads in the quantum library

### DIFF
--- a/quantum/impl/quantum_io_queue_impl.h
+++ b/quantum/impl/quantum_io_queue_impl.h
@@ -447,4 +447,10 @@ bool IoQueue::isIdle() const
     return _isIdle;
 }
 
+inline
+const std::shared_ptr<std::thread>& IoQueue::getThread() const
+{
+    return _thread;
+}
+
 }}

--- a/quantum/impl/quantum_task_queue_impl.h
+++ b/quantum/impl/quantum_task_queue_impl.h
@@ -568,6 +568,12 @@ bool TaskQueue::isIdle() const
 }
 
 inline
+const std::shared_ptr<std::thread>& TaskQueue::getThread() const
+{
+    return _thread;
+}
+
+inline
 void TaskQueue::acquireWaiting()
 {
     //========================= LOCKED SCOPE =========================

--- a/quantum/quantum_dispatcher_core.h
+++ b/quantum/quantum_dispatcher_core.h
@@ -70,11 +70,6 @@ public:
     const std::pair<int, int>& getCoroQueueIdRangeForAny() const;
     
 private:
-    // TODO : Remove - deprecated
-    DispatcherCore(int numCoroutineThreads,
-                   int numIoThreads,
-                   bool pinCoroutineThreadsToCores);
-    
     DispatcherCore(const Configuration& config);
     
     size_t coroSize(int queueId) const;

--- a/quantum/quantum_io_queue.h
+++ b/quantum/quantum_io_queue.h
@@ -80,6 +80,8 @@ public:
     
     bool isIdle() const final;
     
+    const std::shared_ptr<std::thread>& getThread() const final;
+    
 private:
     ITask::Ptr grabWorkItem();
     ITask::Ptr grabWorkItemFromAll();

--- a/quantum/quantum_task_queue.h
+++ b/quantum/quantum_task_queue.h
@@ -84,6 +84,8 @@ public:
     void signalEmptyCondition(bool value) final;
     
     bool isIdle() const final;
+    
+    const std::shared_ptr<std::thread>& getThread() const final;
 
 private:
     struct WorkItem


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
* Rename quantum threads for easier debugging. Threads are named as follows:
[`quantum:` ]+ [`co:` or `io:`] + [`s:` or `a:`] + `num`
where `co` and `io` denote coroutine or async io threads. `s` and `a` denote `shared` and `any` threads for coroutines only.
* Removed deprecated private constructor

**Testing performed**
Validated under GDB
