### PR TITLE
Fixed mem-leak and prevent underruns in stats counter

### DIFF
--- a/quantum/impl/quantum_queue_statistics_impl.h
+++ b/quantum/impl/quantum_queue_statistics_impl.h
@@ -67,7 +67,19 @@ void QueueStatistics::incNumElements()
 inline
 void QueueStatistics::decNumElements()
 {
-    --_numElements;
+    size_t oldValue = 1;
+    size_t newValue = 0;
+    while(!_numElements.compare_exchange_weak(oldValue, newValue, std::memory_order_acq_rel))
+    {
+        if (oldValue == 0)
+        {
+            break;
+        }
+        else
+        {
+            newValue = oldValue - 1;
+        }
+    }
 }
 
 inline

--- a/quantum/quantum_contiguous_pool_manager.h
+++ b/quantum/quantum_contiguous_pool_manager.h
@@ -118,6 +118,9 @@ private:
 
     //------------------------------- Members ----------------------------------
     struct Control {
+        ~Control() {
+            delete[] _freeBlocks;
+        }
         index_type          _size{0};
         aligned_type*       _buffer{nullptr}; //non-owning
         index_type*         _freeBlocks{nullptr};

--- a/quantum/util/impl/quantum_future_joiner_impl.h
+++ b/quantum/util/impl/quantum_future_joiner_impl.h
@@ -60,7 +60,7 @@ FutureJoiner<T>::join(ThreadContextTag, DISPATCHER& dispatcher, std::vector<type
 {
 #if (__cplusplus == 201103L)
     std::shared_ptr<std::vector<typename FUTURE<T>::Ptr>> containerPtr(new std::vector<typename FUTURE<T>::Ptr>(std::move(futures)));
-    return dispatcher.template postAsyncIo<std::vector<T>>([containerPtr](ThreadPromisePtr<std::vector<T>> promise)
+    return dispatcher.template postAsyncIo2<std::vector<T>>([containerPtr]()->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(containerPtr->size());
@@ -68,10 +68,10 @@ FutureJoiner<T>::join(ThreadContextTag, DISPATCHER& dispatcher, std::vector<type
         {
             result.emplace_back(f->get());
         }
-        return promise->set(std::move(result));
+        return result;
     });
 #else
-    return dispatcher.template postAsyncIo<std::vector<T>>([container{std::move(futures)}](ThreadPromisePtr<std::vector<T>> promise)
+    return dispatcher.template postAsyncIo2<std::vector<T>>([container{std::move(futures)}]()->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(container.size());
@@ -79,7 +79,7 @@ FutureJoiner<T>::join(ThreadContextTag, DISPATCHER& dispatcher, std::vector<type
         {
             result.emplace_back(f->get());
         }
-        return promise->set(std::move(result));
+        return result;
     });
 #endif
 }

--- a/tests/quantum_fixture.h
+++ b/tests/quantum_fixture.h
@@ -106,12 +106,13 @@ public:
     void SetUp()
     {
         _dispatcher = &DispatcherSingleton::instance(GetParam());
+        _dispatcher->resetStats();
     }
     
     void TearDown()
     {
         _dispatcher = nullptr;
-        DispatcherSingleton::deleteInstances();
+        //DispatcherSingleton::deleteInstances();
     }
 
     quantum::Dispatcher& getDispatcher()

--- a/tests/quantum_sequencer_tests.cpp
+++ b/tests/quantum_sequencer_tests.cpp
@@ -528,9 +528,3 @@ TEST_P(SequencerTest, CustomHashFunction)
         }
     }
 }
-
-//This test **must** come last to make Valgrind happy.
-TEST(SequencerTestCleanup, DeleteDispatcherInstance)
-{
-    DispatcherSingleton::deleteInstances();
-}

--- a/tests/quantum_spinlocks_tests.cpp
+++ b/tests/quantum_spinlocks_tests.cpp
@@ -19,9 +19,15 @@
 
 using namespace Bloomberg::quantum;
 
+#ifdef BOOST_USE_VALGRIND
+    int spins = 100;
+#else
+    int spins = 1000000;
+#endif
+
 TEST(Spinlock, Spinlock)
 {
-    int num = 1000000;
+    int num = spins;
     int val = 0;
     SpinLock spin;
     std::thread t1([&, num]() mutable {
@@ -60,7 +66,7 @@ TEST(ReadWriteSpinLock, LockReadMultipleTimes)
 
 TEST(ReadWriteSpinLock, LockReadAndWrite)
 {
-    int num = 1000000;
+    int num = spins;
     int val = 0;
     ReadWriteSpinLock spin;
     std::thread t1([&, num]() mutable {
@@ -100,7 +106,7 @@ TEST(ReadWriteSpinLock, LockReadAndWrite)
 
 TEST(ReadWriteSpinLock, LockReadAndWriteList)
 {
-    int num = 1000000;
+    int num = spins;
     std::list<int> val;
     ReadWriteSpinLock spin;
     bool exit = false;


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
* Fixed a small memory leak in the `Control` block of the `ContiguousPoolManager`
* Ensure that capture variable destructors are properly called in the `Function::~Function()` destructor. Previously only the buffer was freed which prevented captured variables from properly deleting their own members.
* Ensure that there are no underruns when decrementing the task counter.
* In the `Sequencer` tests, sped up creation and tear-down of the fixture by not having to create all the Dispatcher variations each time.
* Small changes to some test parameters to speed up when testing with Valgrind. 

**Testing performed**
Ran all GTESTs as well as ran under Valgrind to make sure the tool is not reporting any leaks.
