### PR TITLE
Deduce return type for all API invokable functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Dispatcher dispatcher;
 
 auto ctx = dispatcher.postFirst([](CoroContext<int>::Ptr ctx)->int {
     return ctx->set(55); //Set the 1st value
-})->then<double>([](CoroContext<double>::Ptr ctx)->int {
+})->then([](CoroContext<double>::Ptr ctx)->int {
     // Get the first value and add something to it
     return ctx->set(ctx->getPrev<int>() + 22.33); //Set the 2nd value
-})->then<std::string>([](CoroContext<std::string>::Ptr ctx)->int {
+})->then([](CoroContext<std::string>::Ptr ctx)->int {
     return ctx->set("Hello world!"); //Set the 3rd value
-})->finally<std::list<int>>([](CoroContext<std::list<int>>::Ptr ctx)->int {
+})->finally([](CoroContext<std::list<int>>::Ptr ctx)->int {
     return ctx->set(std::list<int>{1,2,3}); //Set 4th value
 })->end();
 
@@ -83,12 +83,12 @@ Dispatcher dispatcher;
 
 auto ctx = dispatcher.postFirst2([](auto ctx)->int {
     return 55; //Set the 1st value
-})->then2<double>([](auto ctx)->double {
+})->then2([](auto ctx)->double {
     // Get the first value and add something to it
     return ctx->getPrev<int>() + 22.33; //Set the 2nd value
-})->then2<std::string>([](auto ctx)->std::string {
+})->then2([](auto ctx)->std::string {
     return "Hello world!"; //Set the 3rd value
-})->finally2<std::list<int>>([](auto ctx)->std::list<int> {
+})->finally2([](auto ctx)->std::list<int> {
     return {1,2,3}; //Set 4th value
 })->end();
 ```

--- a/quantum/impl/quantum_context_impl.h
+++ b/quantum/impl/quantum_context_impl.h
@@ -102,50 +102,60 @@ const std::pair<int, int>& IThreadContext<RET>::getCoroQueueIdRangeForAny() cons
  
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-ThreadContextPtr<OTHER_RET>
-IThreadContext<RET>::then(FUNC&& func, ARGS&&... args)
+auto
+IThreadContext<RET>::then(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template then<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template then<Ret>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-ThreadContextPtr<OTHER_RET>
-IThreadContext<RET>::then2(FUNC&& func, ARGS&&... args)
+auto
+IThreadContext<RET>::then2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template then2<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template then2<Ret>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-ThreadContextPtr<OTHER_RET>
-IThreadContext<RET>::onError(FUNC&& func, ARGS&&... args)
+auto
+IThreadContext<RET>::onError(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template onError<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template onError<Ret>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-ThreadContextPtr<OTHER_RET>
-IThreadContext<RET>::onError2(FUNC&& func, ARGS&&... args)
+auto
+IThreadContext<RET>::onError2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template onError2<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template onError2<Ret>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-ThreadContextPtr<OTHER_RET>
-IThreadContext<RET>::finally(FUNC&& func, ARGS&&... args)
+auto
+IThreadContext<RET>::finally(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template finally<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template finally<Ret>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-ThreadContextPtr<OTHER_RET>
-IThreadContext<RET>::finally2(FUNC&& func, ARGS&&... args)
+auto
+IThreadContext<RET>::finally2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template finally2<OTHER_RET>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template finally2<Ret>(
+        std::forward<FUNC>(func),
+        std::forward<ARGS>(args)...);
 }
 
 template <class RET>
@@ -252,30 +262,32 @@ const std::pair<int, int>& ICoroContext<RET>::getCoroQueueIdRangeForAny() const
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::post(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::post(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template post<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template post<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::post2(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::post2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template post2<OTHER_RET>(
-        std::forward<FUNC>(func),
-        std::forward<ARGS>(args)...);
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template post2<Ret>
+        (std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template post<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template post<Ret>(
         queueId,
         isHighPriority,
         std::forward<FUNC>(func),
@@ -284,10 +296,11 @@ ICoroContext<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&...
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template post2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template post2<Ret>(
         queueId,
         isHighPriority,
         std::forward<FUNC>(func),
@@ -296,30 +309,33 @@ ICoroContext<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&..
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::postFirst(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postFirst(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template postFirst<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template postFirst<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::postFirst2(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postFirst2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template postFirst2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template postFirst2<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template postFirst<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template postFirst<Ret>(
         queueId,
         isHighPriority,
         std::forward<FUNC>(func),
@@ -328,10 +344,11 @@ ICoroContext<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template postFirst2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template postFirst2<Ret>(
         queueId,
         isHighPriority,
         std::forward<FUNC>(func),
@@ -340,60 +357,66 @@ ICoroContext<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARG
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::then(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::then(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template then<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template then<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::then2(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::then2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template then2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template then2<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::onError(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::onError(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template onError<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template onError<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::onError2(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::onError2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template onError2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template onError2<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::finally(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::finally(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template finally<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template finally<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroContextPtr<OTHER_RET>
-ICoroContext<RET>::finally2(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::finally2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template finally2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template finally2<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
@@ -408,30 +431,33 @@ ICoroContext<RET>::end()
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroFuturePtr<OTHER_RET>
-ICoroContext<RET>::postAsyncIo(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postAsyncIo(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template postAsyncIo<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template postAsyncIo<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroFuturePtr<OTHER_RET>
-ICoroContext<RET>::postAsyncIo2(FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postAsyncIo2(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template postAsyncIo2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template postAsyncIo2<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
 }
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroFuturePtr<OTHER_RET>
-ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf(func))>
 {
-    return static_cast<Impl*>(this)->template postAsyncIo<OTHER_RET>(
+    using Ret = decltype(resultOf(func));
+    return static_cast<Impl*>(this)->template postAsyncIo<Ret>(
         queueId,
         isHighPriority,
         std::forward<FUNC>(func),
@@ -440,10 +466,11 @@ ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, AR
 
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroFuturePtr<OTHER_RET>
-ICoroContext<RET>::postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+auto
+ICoroContext<RET>::postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf2(func))>
 {
-    return static_cast<Impl*>(this)->template postAsyncIo2<OTHER_RET>(
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template postAsyncIo2<Ret>(
         queueId,
         isHighPriority,
         std::forward<FUNC>(func),
@@ -452,57 +479,67 @@ ICoroContext<RET>::postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, A
 
 template <class RET>
 template <class OTHER_RET, class INPUT_IT, class FUNC, class>
-CoroContextPtr<std::vector<OTHER_RET>>
+auto
 ICoroContext<RET>::forEach(INPUT_IT first,
                            INPUT_IT last,
-                           FUNC&& func)
+                           FUNC&& func)->CoroContextPtr<std::vector<decltype(resultOf2(func))>>
 {
-    return static_cast<Impl*>(this)->template forEach<OTHER_RET>(first, last, std::forward<FUNC>(func));
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template forEach<Ret>(first, last, std::forward<FUNC>(func));
 }
 
 template <class RET>
 template <class OTHER_RET, class INPUT_IT, class FUNC>
-CoroContextPtr<std::vector<OTHER_RET>>
+auto
 ICoroContext<RET>::forEach(INPUT_IT first,
                            size_t num,
-                           FUNC&& func)
+                           FUNC&& func)->CoroContextPtr<std::vector<decltype(resultOf2(func))>>
 {
-    return static_cast<Impl*>(this)->template forEach<OTHER_RET>(first, num, std::forward<FUNC>(func));
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template forEach<Ret>(first, num, std::forward<FUNC>(func));
 }
 
 template <class RET>
 template <class OTHER_RET, class INPUT_IT, class FUNC, class>
-CoroContextPtr<std::vector<std::vector<OTHER_RET>>>
+auto
 ICoroContext<RET>::forEachBatch(INPUT_IT first,
                                 INPUT_IT last,
-                                FUNC&& func)
+                                FUNC&& func)->CoroContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
 {
-    return static_cast<Impl*>(this)->template forEachBatch<OTHER_RET>(first, last, std::forward<FUNC>(func));
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template forEachBatch<Ret>(first, last, std::forward<FUNC>(func));
 }
 
 template <class RET>
 template <class OTHER_RET, class INPUT_IT, class FUNC>
-CoroContextPtr<std::vector<std::vector<OTHER_RET>>>
+auto
 ICoroContext<RET>::forEachBatch(INPUT_IT first,
                                 size_t num,
-                                FUNC&& func)
+                                FUNC&& func)->CoroContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
 {
-    return static_cast<Impl*>(this)->template forEachBatch<OTHER_RET>(first, num, std::forward<FUNC>(func));
+    using Ret = decltype(resultOf2(func));
+    return static_cast<Impl*>(this)->template forEachBatch<Ret>(first, num, std::forward<FUNC>(func));
 }
 
 template <class RET>
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
           class INPUT_IT,
           class>
-CoroContextPtr<std::map<KEY, REDUCED_TYPE>>
+auto
 ICoroContext<RET>::mapReduce(INPUT_IT first,
                              INPUT_IT last,
-                             Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                             Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                             MAPPER_FUNC mapper,
+                             REDUCER_FUNC reducer)->
+          CoroContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
-    return static_cast<Impl*>(this)->template mapReduce<KEY, MAPPED_TYPE, REDUCED_TYPE>
+    using Key = decltype(mappedKeyOf(mapper));
+    using MappedType = decltype(mappedTypeOf(mapper));
+    using ReducedType = decltype(reducedTypeOf(reducer));
+    return static_cast<Impl*>(this)->template mapReduce<Key, MappedType, ReducedType>
         (first, last, std::move(mapper), std::move(reducer));
 }
 
@@ -510,14 +547,21 @@ template <class RET>
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
-          class INPUT_IT>
-CoroContextPtr<std::map<KEY, REDUCED_TYPE>>
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
+          class INPUT_IT,
+          class>
+auto
 ICoroContext<RET>::mapReduce(INPUT_IT first,
                              size_t num,
-                             Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                             Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                             MAPPER_FUNC mapper,
+                             REDUCER_FUNC reducer)->
+          CoroContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
-    return static_cast<Impl*>(this)->template mapReduce<KEY, MAPPED_TYPE, REDUCED_TYPE>
+    using Key = decltype(mappedKeyOf(mapper));
+    using MappedType = decltype(mappedTypeOf(mapper));
+    using ReducedType = decltype(reducedTypeOf(reducer));
+    return static_cast<Impl*>(this)->template mapReduce<Key, MappedType, ReducedType>
         (first, num, std::move(mapper), std::move(reducer));
 }
 
@@ -525,15 +569,21 @@ template <class RET>
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
           class INPUT_IT,
           class>
-CoroContextPtr<std::map<KEY, REDUCED_TYPE>>
+auto
 ICoroContext<RET>::mapReduceBatch(INPUT_IT first,
                                   INPUT_IT last,
-                                  Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                                  Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                                  MAPPER_FUNC mapper,
+                                  REDUCER_FUNC reducer)->
+          CoroContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
-    return static_cast<Impl*>(this)->template mapReduceBatch<KEY, MAPPED_TYPE, REDUCED_TYPE>
+    using Key = decltype(mappedKeyOf(mapper));
+    using MappedType = decltype(mappedTypeOf(mapper));
+    using ReducedType = decltype(reducedTypeOf(reducer));
+    return static_cast<Impl*>(this)->template mapReduceBatch<Key, MappedType, ReducedType>
         (first, last, std::move(mapper), std::move(reducer));
 }
 
@@ -541,14 +591,21 @@ template <class RET>
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
-          class INPUT_IT>
-CoroContextPtr<std::map<KEY, REDUCED_TYPE>>
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
+          class INPUT_IT,
+          class>
+auto
 ICoroContext<RET>::mapReduceBatch(INPUT_IT first,
                                   size_t num,
-                                  Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                                  Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                                  MAPPER_FUNC mapper,
+                                  REDUCER_FUNC reducer)->
+          CoroContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
-    return static_cast<Impl*>(this)->template mapReduceBatch<KEY, MAPPED_TYPE, REDUCED_TYPE>
+    using Key = decltype(mappedKeyOf(mapper));
+    using MappedType = decltype(mappedTypeOf(mapper));
+    using ReducedType = decltype(reducedTypeOf(reducer));
+    return static_cast<Impl*>(this)->template mapReduceBatch<Key, MappedType, ReducedType>
         (first, num, std::move(mapper), std::move(reducer));
 }
 

--- a/quantum/impl/quantum_dispatcher_impl.h
+++ b/quantum/impl/quantum_dispatcher_impl.h
@@ -34,16 +34,17 @@ Dispatcher::Dispatcher(const Configuration& config) :
 inline
 Dispatcher::~Dispatcher()
 {
-    drain();
+    drain(std::chrono::milliseconds::zero(), true);
     terminate();
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::post(FUNC&& func,
-                 ARGS&&... args)
+                 ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return postImpl<RET>((int)IQueue::QueueId::Any,
+    using Ret = decltype(resultOf(func));
+    return postImpl<Ret>((int)IQueue::QueueId::Any,
                          false,
                          ITask::Type::Standalone,
                          std::forward<FUNC>(func),
@@ -51,11 +52,12 @@ Dispatcher::post(FUNC&& func,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::post2(FUNC&& func,
-                  ARGS&&... args)
+                  ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return postImpl2<RET>((int)IQueue::QueueId::Any,
+    using Ret = decltype(resultOf2(func));
+    return postImpl2<Ret>((int)IQueue::QueueId::Any,
                           false,
                           ITask::Type::Standalone,
                           std::forward<FUNC>(func),
@@ -63,13 +65,14 @@ Dispatcher::post2(FUNC&& func,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::post(int queueId,
                  bool isHighPriority,
                  FUNC&& func,
-                 ARGS&&... args)
+                 ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return postImpl<RET>(queueId,
+    using Ret = decltype(resultOf(func));
+    return postImpl<Ret>(queueId,
                          isHighPriority,
                          ITask::Type::Standalone,
                          std::forward<FUNC>(func),
@@ -77,13 +80,14 @@ Dispatcher::post(int queueId,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::post2(int queueId,
                   bool isHighPriority,
                   FUNC&& func,
-                  ARGS&&... args)
+                  ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return postImpl2<RET>(queueId,
+    using Ret = decltype(resultOf2(func));
+    return postImpl2<Ret>(queueId,
                           isHighPriority,
                           ITask::Type::Standalone,
                           std::forward<FUNC>(func),
@@ -91,22 +95,24 @@ Dispatcher::post2(int queueId,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::postFirst(FUNC&& func,
-                      ARGS&&... args)
+                      ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return postImpl<RET>((int)IQueue::QueueId::Any,
+    using Ret = decltype(resultOf(func));
+    return postImpl<Ret>((int)IQueue::QueueId::Any,
                          false, ITask::Type::First,
                          std::forward<FUNC>(func),
                          std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::postFirst2(FUNC&& func,
-                       ARGS&&... args)
+                       ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return postImpl2<RET>((int)IQueue::QueueId::Any,
+    using Ret = decltype(resultOf2(func));
+    return postImpl2<Ret>((int)IQueue::QueueId::Any,
                           false,
                           ITask::Type::First,
                           std::forward<FUNC>(func),
@@ -114,13 +120,14 @@ Dispatcher::postFirst2(FUNC&& func,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::postFirst(int queueId,
                       bool isHighPriority,
                       FUNC&& func,
-                      ARGS&&... args)
+                      ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
 {
-    return postImpl<RET>(queueId,
+    using Ret = decltype(resultOf(func));
+    return postImpl<Ret>(queueId,
                          isHighPriority,
                          ITask::Type::First,
                          std::forward<FUNC>(func),
@@ -128,13 +135,14 @@ Dispatcher::postFirst(int queueId,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
+auto
 Dispatcher::postFirst2(int queueId,
                        bool isHighPriority,
                        FUNC&& func,
-                       ARGS&&... args)
+                       ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
-    return postImpl2<RET>(queueId,
+    using Ret = decltype(resultOf2(func));
+    return postImpl2<Ret>(queueId,
                           isHighPriority,
                           ITask::Type::First,
                           std::forward<FUNC>(func),
@@ -142,105 +150,114 @@ Dispatcher::postFirst2(int queueId,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadFuturePtr<RET>
+auto
 Dispatcher::postAsyncIo(FUNC&& func,
-                        ARGS&&... args)
+                        ARGS&&... args)->ThreadFuturePtr<decltype(resultOf(func))>
 {
-    return postAsyncIoImpl<RET>((int)IQueue::QueueId::Any,
+    using Ret = decltype(resultOf(func));
+    return postAsyncIoImpl<Ret>((int)IQueue::QueueId::Any,
                                 false,
                                 std::forward<FUNC>(func),
                                 std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadFuturePtr<RET>
+auto
 Dispatcher::postAsyncIo2(FUNC&& func,
-                         ARGS&&... args)
+                         ARGS&&... args)->ThreadFuturePtr<decltype(resultOf2(func))>
 {
-    return postAsyncIoImpl2<RET>((int)IQueue::QueueId::Any,
+    using Ret = decltype(resultOf2(func));
+    return postAsyncIoImpl2<Ret>((int)IQueue::QueueId::Any,
                                  false, std::forward<FUNC>(func),
                                  std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadFuturePtr<RET>
+auto
 Dispatcher::postAsyncIo(int queueId,
                         bool isHighPriority,
                         FUNC&& func,
-                        ARGS&&... args)
+                        ARGS&&... args)->ThreadFuturePtr<decltype(resultOf(func))>
 {
-    return postAsyncIoImpl<RET>(queueId,
+    using Ret = decltype(resultOf(func));
+    return postAsyncIoImpl<Ret>(queueId,
                                 isHighPriority,
                                 std::forward<FUNC>(func),
                                 std::forward<ARGS>(args)...);
 }
 
 template <class RET, class FUNC, class ... ARGS>
-ThreadFuturePtr<RET>
+auto
 Dispatcher::postAsyncIo2(int queueId,
                          bool isHighPriority,
                          FUNC&& func,
-                         ARGS&&... args)
+                         ARGS&&... args)->ThreadFuturePtr<decltype(resultOf2(func))>
 {
-    return postAsyncIoImpl2<RET>(queueId,
+    using Ret = decltype(resultOf2(func));
+    return postAsyncIoImpl2<Ret>(queueId,
                                  isHighPriority,
                                  std::forward<FUNC>(func),
                                  std::forward<ARGS>(args)...);
 }
 
 template <class RET, class INPUT_IT, class FUNC, class>
-ThreadContextPtr<std::vector<RET>>
+auto
 Dispatcher::forEach(INPUT_IT first,
                     INPUT_IT last,
-                    FUNC&& func)
+                    FUNC&& func)->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>
 {
-    return forEach<RET>(first, std::distance(first, last), std::forward<FUNC>(func));
+    return forEach(first, std::distance(first, last), std::forward<FUNC>(func));
 }
 
 template <class RET, class INPUT_IT, class FUNC>
-ThreadContextPtr<std::vector<RET>>
+auto
 Dispatcher::forEach(INPUT_IT first,
                     size_t num,
-                    FUNC&& func)
+                    FUNC&& func)->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>
 {
-    return post2<std::vector<RET>>(Util::forEachCoro<RET, INPUT_IT, FUNC&&>,
-                                   INPUT_IT{first},
-                                   size_t{num},
-                                   std::forward<FUNC>(func));
+    using Ret = decltype(resultOf2(func));
+    return post2(Util::forEachCoro<Ret, INPUT_IT, FUNC&&>,
+                 INPUT_IT{first},
+                 size_t{num},
+                 std::forward<FUNC>(func));
 }
 
 template <class RET, class INPUT_IT, class FUNC, class>
-ThreadContextPtr<std::vector<std::vector<RET>>>
+auto
 Dispatcher::forEachBatch(INPUT_IT first,
                          INPUT_IT last,
-                         FUNC&& func)
+                         FUNC&& func)->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
 {
-    return forEachBatch<RET>(first, std::distance(first, last), std::forward<FUNC>(func));
+    return forEachBatch(first, std::distance(first, last), std::forward<FUNC>(func));
 }
 
 template <class RET, class INPUT_IT, class FUNC>
-ThreadContextPtr<std::vector<std::vector<RET>>>
+auto
 Dispatcher::forEachBatch(INPUT_IT first,
                          size_t num,
-                         FUNC&& func)
+                         FUNC&& func)->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
 {
-    return post2<std::vector<std::vector<RET>>>(Util::forEachBatchCoro<RET, INPUT_IT, FUNC&&>,
-                                               INPUT_IT{first},
-                                               size_t{num},
-                                               std::forward<FUNC>(func),
-                                               getNumCoroutineThreads());
+    using Ret = decltype(resultOf2(func));
+    return post2(Util::forEachBatchCoro<Ret, INPUT_IT, FUNC&&>,
+                 INPUT_IT{first},
+                 size_t{num},
+                 std::forward<FUNC>(func),
+                 getNumCoroutineThreads());
 }
 
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
           class INPUT_IT,
           class>
-ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
+auto
 Dispatcher::mapReduce(INPUT_IT first,
                       INPUT_IT last,
-                      Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                      Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                      MAPPER_FUNC mapper,
+                      REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
     return mapReduce(first, std::distance(first, last), std::move(mapper), std::move(reducer));
 }
@@ -248,31 +265,40 @@ Dispatcher::mapReduce(INPUT_IT first,
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
-          class INPUT_IT>
-ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
+          class INPUT_IT,
+          class>
+auto
 Dispatcher::mapReduce(INPUT_IT first,
                       size_t num,
-                      Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                      Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                      MAPPER_FUNC mapper,
+                      REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
-    using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
-    return post2<ReducerOutput>(Util::mapReduceCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
-                               INPUT_IT{first},
-                               size_t{num},
-                               Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>{std::move(mapper)},
-                               Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE>{std::move(reducer)});
+    using Key = decltype(mappedKeyOf(mapper));
+    using MappedType = decltype(mappedTypeOf(mapper));
+    using ReducedType = decltype(reducedTypeOf(reducer));
+    return post2(Util::mapReduceCoro<Key, MappedType, ReducedType, INPUT_IT>,
+                 INPUT_IT{first},
+                 size_t{num},
+                 Functions::MapFunc<Key, MappedType, INPUT_IT>{std::move(mapper)},
+                 Functions::ReduceFunc<Key, MappedType, ReducedType>{std::move(reducer)});
 }
 
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
           class INPUT_IT,
           class>
-ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
+auto
 Dispatcher::mapReduceBatch(INPUT_IT first,
                            INPUT_IT last,
-                           Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                           Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                           MAPPER_FUNC mapper,
+                           REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
     return mapReduceBatch(first, std::distance(first, last), std::move(mapper), std::move(reducer));
 }
@@ -280,19 +306,25 @@ Dispatcher::mapReduceBatch(INPUT_IT first,
 template <class KEY,
           class MAPPED_TYPE,
           class REDUCED_TYPE,
-          class INPUT_IT>
-ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
+          class MAPPER_FUNC,
+          class REDUCER_FUNC,
+          class INPUT_IT,
+          class>
+auto
 Dispatcher::mapReduceBatch(INPUT_IT first,
                            size_t num,
-                           Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                           Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer)
+                           MAPPER_FUNC mapper,
+                           REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>
 {
-    using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
-    return post2<ReducerOutput>(Util::mapReduceBatchCoro<KEY, MAPPED_TYPE, REDUCED_TYPE, INPUT_IT>,
-                               INPUT_IT{first},
-                               size_t{num},
-                               Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT>{std::move(mapper)},
-                               Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE>{std::move(reducer)});
+    using Key = decltype(mappedKeyOf(mapper));
+    using MappedType = decltype(mappedTypeOf(mapper));
+    using ReducedType = decltype(reducedTypeOf(reducer));
+    return post2(Util::mapReduceBatchCoro<Key, MappedType, ReducedType, INPUT_IT>,
+                 INPUT_IT{first},
+                 size_t{num},
+                 Functions::MapFunc<Key, MappedType, INPUT_IT>{std::move(mapper)},
+                 Functions::ReduceFunc<Key, MappedType, ReducedType>{std::move(reducer)});
 }
 
 inline
@@ -320,9 +352,10 @@ bool Dispatcher::empty(IQueue::QueueType type,
 }
 
 inline
-void Dispatcher::drain(std::chrono::milliseconds timeout)
+void Dispatcher::drain(std::chrono::milliseconds timeout,
+                       bool isFinal)
 {
-    DrainGuard guard(_drain);
+    DrainGuard guard(_drain, !isFinal);
     
     auto start = std::chrono::steady_clock::now();
     

--- a/quantum/interface/quantum_icoro_context.h
+++ b/quantum/interface/quantum_icoro_context.h
@@ -181,14 +181,12 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine context object.
     /// @note This function is non-blocking and returns immediately. The returned context cannot be used to chain
     ///       further coroutines.
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    post(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto post(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    post2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto post2(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Post a coroutine to run asynchronously.
     /// @details This method will post the coroutine on the specified queue (thread) with high or low priority.
@@ -209,14 +207,14 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine context object.
     /// @note This function is non-blocking and returns immediately. The returned context cannot be used to chain
     ///       further coroutines.
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a coroutine to run asynchronously.
     /// @details This function is the head of a coroutine continuation chain and must be called only once in the chain.
@@ -230,14 +228,12 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine context object.
     /// @note This function is non-blocking and returns immediately. The returned context can be used to chain
     ///       further coroutines. Possible method calls following this are then(), onError(), finally() and end().
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    postFirst(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    postFirst2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst2(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a coroutine to run asynchronously.
     /// @details This function is the head of a coroutine continuation chain and must be called only once in the chain.
@@ -258,14 +254,14 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine context object.
     /// @note This function is non-blocking and returns immediately. The returned context can be used to chain
     ///       further coroutines. Possible method calls following this are then(), onError(), finally() and end().
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a coroutine to run asynchronously.
     /// @details This function is optional for the continuation chain and may be called 0 or more times. If called,
@@ -281,14 +277,12 @@ struct ICoroContext : ICoroContextBase
     /// @note This function is non-blocking and runs when all previous chained coroutines have completed.
     ///       The returned context can be used to chain further coroutines. Possible method calls following this
     ///       are then(), onError(), finally() and end().
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    then(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto then(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    then2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto then2(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a coroutine to run asynchronously. This is the error handler for a continuation chain and acts as
     ///        as a 'catch' clause.
@@ -307,14 +301,12 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine context object.
     /// @note The function is non-blocking. The returned context can be used to chain further coroutines.
     ///       Possible method calls following this are finally() and end().
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    onError(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto onError(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    onError2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto onError2(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a coroutine to run asynchronously. This coroutine is always guaranteed to run.
     /// @details This function is optional for the continuation chain and may be called at most once. If called, it must
@@ -329,14 +321,12 @@ struct ICoroContext : ICoroContextBase
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @return A pointer to a coroutine context object.
     /// @note This function is non-blocking and returns immediately. After this coroutine, the end() method must be called.
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    finally(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto finally(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename ICoroContext<OTHER_RET>::Ptr
-    finally2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto finally2(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief This is the last method in a continuation chain.
     /// @details This method effectively closes the continuation chain and posts the entire chain to be executed,
@@ -355,14 +345,12 @@ struct ICoroContext : ICoroContextBase
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @return A pointer to a coroutine future object which may be used to retrieve the result of the IO operation.
     /// @note This method does not block. The passed function will not be wrapped in a coroutine.
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    CoroFuturePtr<OTHER_RET>
-    postAsyncIo(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    CoroFuturePtr<OTHER_RET>
-    postAsyncIo2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo2(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf2(func))>;
     
     /// @brief Posts an IO function to run asynchronously on the IO thread pool.
     /// @details This method will post the function on the specified queue (thread) with high or low priority.
@@ -380,14 +368,14 @@ struct ICoroContext : ICoroContextBase
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @return A pointer to a coroutine future object which may be used to retrieve the result of the IO operation.
     /// @note This method does not block. The passed function will not be wrapped in a coroutine.
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    CoroFuturePtr<OTHER_RET>
-    postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->CoroFuturePtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    CoroFuturePtr<OTHER_RET>
-    postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->CoroFuturePtr<decltype(resultOf2(func))>;
     
     /// @brief Applies the given unary function to all the elements in the range [first,last).
     ///        This function runs in parallel.
@@ -403,20 +391,20 @@ struct ICoroContext : ICoroContextBase
     ///       Prefer this function over forEachBatch() if performing IO inside FUNC.
     /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
     ///          However it should *not* be set and this will result in undefined behavior.
-    template <class OTHER_RET = int,
+    template <class OTHER_RET = Deprecated,
               class INPUT_IT,
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
-    typename ICoroContext<std::vector<OTHER_RET>>::Ptr
-    forEach(INPUT_IT first, INPUT_IT last, FUNC&& func);
+    auto forEach(INPUT_IT first, INPUT_IT last, FUNC&& func)
+        ->typename ICoroContext<std::vector<decltype(resultOf2(func))>>::Ptr;
     
     /// @brief Same as forEach() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class OTHER_RET = int,
+    template <class OTHER_RET = Deprecated,
               class INPUT_IT,
               class FUNC>
-    typename ICoroContext<std::vector<OTHER_RET>>::Ptr
-    forEach(INPUT_IT first, size_t num, FUNC&& func);
+    auto forEach(INPUT_IT first, size_t num, FUNC&& func)
+        ->typename ICoroContext<std::vector<decltype(resultOf2(func))>>::Ptr;
     
     /// @brief The batched version of forEach(). This function applies the given unary function
     ///        to all the elements in the range [first,last). This function runs serially with respect
@@ -425,20 +413,20 @@ struct ICoroContext : ICoroContextBase
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
     /// @note The input range is split equally among coroutines and executed in batches. This function
     ///       achieves higher throughput rates than the non-batched mode, if FUNC is CPU-bound.
-    template <class OTHER_RET = int,
+    template <class OTHER_RET = Deprecated,
               class INPUT_IT,
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
-    typename ICoroContext<std::vector<std::vector<OTHER_RET>>>::Ptr
-    forEachBatch(INPUT_IT first, INPUT_IT last, FUNC&& func);
+    auto forEachBatch(INPUT_IT first, INPUT_IT last, FUNC&& func)
+        ->typename ICoroContext<std::vector<std::vector<decltype(resultOf2(func))>>>::Ptr;
     
     /// @brief Same as forEachBatch() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class OTHER_RET = int,
+    template <class OTHER_RET = Deprecated,
               class INPUT_IT,
               class FUNC>
-    typename ICoroContext<std::vector<std::vector<OTHER_RET>>>::Ptr
-    forEachBatch(INPUT_IT first, size_t num, FUNC&& func);
+    auto forEachBatch(INPUT_IT first, size_t num, FUNC&& func)
+        ->typename ICoroContext<std::vector<std::vector<decltype(resultOf2(func))>>>::Ptr;
     
     /// @brief Implementation of map-reduce functionality.
     /// @tparam KEY The KEY type used for mapping and reducing.
@@ -457,55 +445,65 @@ struct ICoroContext : ICoroContextBase
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
     /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
     ///          However it should *not* be set and this will result in undefined behavior.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
               class INPUT_IT,
               class = Traits::IsInputIterator<INPUT_IT>>
-    typename ICoroContext<std::map<KEY, REDUCED_TYPE>>::Ptr
-    mapReduce(INPUT_IT first,
-              INPUT_IT last,
-              Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-              Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    auto mapReduce(INPUT_IT first,
+                   INPUT_IT last,
+                   MAPPER_FUNC mapper,
+                   REDUCER_FUNC reducer)->
+          typename ICoroContext<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>::Ptr;
   
     /// @brief Same as mapReduce() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
-              class INPUT_IT>
-    typename ICoroContext<std::map<KEY, REDUCED_TYPE>>::Ptr
-    mapReduce(INPUT_IT first,
-              size_t num,
-              Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-              Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
+              class INPUT_IT,
+              class = Traits::IsInputIterator<INPUT_IT>>
+    auto mapReduce(INPUT_IT first,
+                   size_t num,
+                   MAPPER_FUNC mapper,
+                   REDUCER_FUNC reducer)->
+          typename ICoroContext<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>::Ptr;
     
     /// @brief This version of mapReduce() runs both the mapper and the reducer functions in batches
     ///        for improved performance. This should be used in the case where the functions are
     ///        more CPU intensive with little or no IO.
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
               class INPUT_IT,
               class = Traits::IsInputIterator<INPUT_IT>>
-    typename ICoroContext<std::map<KEY, REDUCED_TYPE>>::Ptr
-    mapReduceBatch(INPUT_IT first,
-                   INPUT_IT last,
-                   Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                   Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    auto mapReduceBatch(INPUT_IT first,
+                        INPUT_IT last,
+                        MAPPER_FUNC mapper,
+                        REDUCER_FUNC reducer)->
+          typename ICoroContext<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>::Ptr;
     
     /// @brief Same as mapReduceBatch() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
-              class INPUT_IT>
-    typename ICoroContext<std::map<KEY, REDUCED_TYPE>>::Ptr
-    mapReduceBatch(INPUT_IT first,
-                   size_t num,
-                   Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                   Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
+              class INPUT_IT,
+              class = Traits::IsInputIterator<INPUT_IT>>
+    auto mapReduceBatch(INPUT_IT first,
+                        size_t num,
+                        MAPPER_FUNC mapper,
+                        REDUCER_FUNC reducer)->
+          typename ICoroContext<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>::Ptr;
 };
 
 template <class RET>
@@ -515,6 +513,9 @@ template <class RET>
 using CoroContextPtr = typename ICoroContext<RET>::Ptr;
 using VoidCoroContextPtr = CoroContextPtr<Void>;
 using VoidContextPtr = VoidCoroContextPtr; //shorthand version
+
+template <class RET>
+struct Traits::InnerType<std::shared_ptr<ICoroContext<RET>>> { using Type = RET;};
 
 }}
 

--- a/quantum/interface/quantum_ithread_context.h
+++ b/quantum/interface/quantum_ithread_context.h
@@ -187,14 +187,12 @@ struct IThreadContext : public IThreadContextBase
     /// @note This function is non-blocking and runs when all previous chained functions have completed.
     ///       The returned context can be used to chain further functions. Possible method calls following this
     ///       are then(), onError(), finally() and end().
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename IThreadContext<OTHER_RET>::Ptr
-    then(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto then(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename IThreadContext<OTHER_RET>::Ptr
-    then2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto then2(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a function to run asynchronously. This is the error handler for a continuation chain and acts as
     ///        as a 'catch' clause.
@@ -212,14 +210,12 @@ struct IThreadContext : public IThreadContextBase
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note The function is non-blocking. The returned context can be used to chain further functions.
     ///       Possible method calls following this are finally() and end().
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename IThreadContext<OTHER_RET>::Ptr
-    onError(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto onError(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename IThreadContext<OTHER_RET>::Ptr
-    onError2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto onError2(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief Posts a function to run asynchronously. This function is always guaranteed to run.
     /// @details This function is optional for the continuation chain and may be called at most once. If called, it must
@@ -233,14 +229,12 @@ struct IThreadContext : public IThreadContextBase
     /// @param[in] func Callable object.
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately. After this function, the end() method must be called.
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename IThreadContext<OTHER_RET>::Ptr
-    finally(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto finally(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class OTHER_RET = int, class FUNC, class ... ARGS>
-    typename IThreadContext<OTHER_RET>::Ptr
-    finally2(FUNC&& func, ARGS&&... args);
+    template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
+    auto finally2(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf2(func))>::Ptr;
     
     /// @brief This is the last method in a continuation chain.
     /// @details This method effectively closes the continuation chain and posts the entire chain to be executed,

--- a/quantum/interface/quantum_ithread_promise.h
+++ b/quantum/interface/quantum_ithread_promise.h
@@ -81,6 +81,9 @@ using ThreadPromise = IThreadPromise<Promise,T>;
 template <class T>
 using ThreadPromisePtr = typename IThreadPromise<Promise,T>::Ptr;
 
+template <class T>
+struct Traits::InnerType<std::shared_ptr<IThreadPromise<Promise, T>>> { using Type = T;};
+
 }}
 
 #endif //BLOOMBERG_QUANTUM_ITHREAD_PROMISE_H

--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -58,15 +58,12 @@ public:
     /// @return A pointer to a thread context object.
     /// @note This function is non-blocking and returns immediately. The returned thread context cannot be used to chain
     ///       further coroutines.
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    post(FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto post(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    post2(FUNC&& func, ARGS&&... args);
-    
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto post2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>;
     
     /// @brief Post a coroutine to run asynchronously on a specific queue (thread).
     /// @tparam RET Type of future returned by this coroutine.
@@ -84,14 +81,14 @@ public:
     /// @return A pointer to a thread context object.
     /// @note This function is non-blocking and returns immediately. The returned thread context cannot be used to chain
     ///       further coroutines.
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->ThreadContextPtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->ThreadContextPtr<decltype(resultOf2(func))>;
     
     /// @brief Post the first coroutine in a continuation chain to run asynchronously.
     /// @tparam RET Type of future returned by this coroutine.
@@ -104,14 +101,12 @@ public:
     /// @return A pointer to a thread context object.
     /// @note This function is non-blocking and returns immediately. The returned context can be used to chain other
     ///       coroutines which will run sequentially.
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    postFirst(FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    postFirst2(FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>;
     
     /// @brief Post the first coroutine in a continuation chain to run asynchronously on a specific queue (thread).
     /// @tparam RET Type of future returned by this coroutine.
@@ -129,14 +124,14 @@ public:
     /// @return A pointer to a thread context object.
     /// @note This function is non-blocking and returns immediately. The returned context can be used to chain other
     ///       coroutines which will run sequentially.
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->ThreadContextPtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->ThreadContextPtr<decltype(resultOf2(func))>;
     
     /// @brief Post a blocking IO (or long running) task to run asynchronously on the IO thread pool.
     /// @tparam RET Type of future returned by this task.
@@ -148,14 +143,12 @@ public:
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @return A pointer to a thread future object.
     /// @note This function is non-blocking and returns immediately. The passed function will not be wrapped in a coroutine.
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadFuturePtr<RET>
-    postAsyncIo(FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo(FUNC&& func, ARGS&&... args)->ThreadFuturePtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadFuturePtr<RET>
-    postAsyncIo2(FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo2(FUNC&& func, ARGS&&... args)->ThreadFuturePtr<decltype(resultOf2(func))>;
     
     /// @brief Post a blocking IO (or long running) task to run asynchronously on a specific thread in the IO thread pool.
     /// @tparam RET Type of future returned by this task.
@@ -171,14 +164,14 @@ public:
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @return A pointer to a thread future object.
     /// @note This function is non-blocking and returns immediately. The passed function will not be wrapped in a coroutine.
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadFuturePtr<RET>
-    postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->ThreadFuturePtr<decltype(resultOf(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
-    template <class RET = int, class FUNC, class ... ARGS>
-    ThreadFuturePtr<RET>
-    postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
+    template <class RET = Deprecated, class FUNC, class ... ARGS>
+    auto postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
+        ->ThreadFuturePtr<decltype(resultOf2(func))>;
     
     /// @brief Applies the given unary function to all the elements in the range [first,last).
     ///        This function runs in parallel.
@@ -194,20 +187,20 @@ public:
     ///       Prefer this function over forEachBatch() if performing IO inside FUNC.
     /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
     ///          However it should *not* be set and this will result in undefined behavior.
-    template <class RET = int,
+    template <class RET = Deprecated,
               class INPUT_IT,
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
-    ThreadContextPtr<std::vector<RET>>
-    forEach(INPUT_IT first, INPUT_IT last, FUNC&& func);
+    auto forEach(INPUT_IT first, INPUT_IT last, FUNC&& func)
+        ->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>;
     
     /// @brief Same as forEach() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class RET = int,
+    template <class RET = Deprecated,
               class INPUT_IT,
               class FUNC>
-    ThreadContextPtr<std::vector<RET>>
-    forEach(INPUT_IT first, size_t num, FUNC&& func);
+    auto forEach(INPUT_IT first, size_t num, FUNC&& func)
+        ->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>;
     
     /// @brief The batched version of forEach(). This function applies the given unary function
     ///        to all the elements in the range [first,last). This function runs serially with respect
@@ -216,20 +209,20 @@ public:
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
     /// @note The input range is split equally among coroutines and executed in batches. This function
     ///       achieves higher throughput rates than the non-batched mode, if FUNC is CPU-bound.
-    template <class RET = int,
+    template <class RET = Deprecated,
               class INPUT_IT,
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
-    ThreadContextPtr<std::vector<std::vector<RET>>>
-    forEachBatch(INPUT_IT first, INPUT_IT last, FUNC&& func);
+    auto forEachBatch(INPUT_IT first, INPUT_IT last, FUNC&& func)
+        ->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>;
     
     /// @brief Same as forEachBatch() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class RET = int,
+    template <class RET = Deprecated,
               class INPUT_IT,
               class FUNC>
-    ThreadContextPtr<std::vector<std::vector<RET>>>
-    forEachBatch(INPUT_IT first, size_t num, FUNC&& func);
+    auto forEachBatch(INPUT_IT first, size_t num, FUNC&& func)
+        ->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>;
     
     /// @brief Implementation of map-reduce functionality.
     /// @tparam KEY The KEY type used for mapping and reducing.
@@ -248,55 +241,65 @@ public:
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
     /// @warning The VoidContextPtr can be used to yield() or to post additional coroutines or IO tasks.
     ///          However it should *not* be set and this will result in undefined behavior.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
               class INPUT_IT,
               class = Traits::IsInputIterator<INPUT_IT>>
-    ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
-    mapReduce(INPUT_IT first,
-              INPUT_IT last,
-              Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-              Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    auto mapReduce(INPUT_IT first,
+                   INPUT_IT last,
+                   MAPPER_FUNC mapper,
+                   REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>;
   
     /// @brief Same as mapReduce() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
-              class INPUT_IT>
-    ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
-    mapReduce(INPUT_IT first,
-              size_t num,
-              Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-              Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
+              class INPUT_IT,
+              class = Traits::IsInputIterator<INPUT_IT>>
+    auto mapReduce(INPUT_IT first,
+                   size_t num,
+                   MAPPER_FUNC mapper,
+                   REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>;
     
     /// @brief This version of mapReduce() runs both the mapper and the reducer functions in batches
     ///        for improved performance. This should be used in the case where the functions are
     ///        more CPU intensive with little or no IO.
     /// @note Use this function if InputIt meets the requirement of a RandomAccessIterator.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
               class INPUT_IT,
               class = Traits::IsInputIterator<INPUT_IT>>
-    ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
-    mapReduceBatch(INPUT_IT first,
-                   INPUT_IT last,
-                   Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                   Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    auto mapReduceBatch(INPUT_IT first,
+                        INPUT_IT last,
+                        MAPPER_FUNC mapper,
+                        REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>;
     
     /// @brief Same as mapReduceBatch() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
-    template <class KEY,
-              class MAPPED_TYPE,
-              class REDUCED_TYPE,
-              class INPUT_IT>
-    ThreadContextPtr<std::map<KEY, REDUCED_TYPE>>
-    mapReduceBatch(INPUT_IT first,
-                   size_t num,
-                   Functions::MapFunc<KEY, MAPPED_TYPE, INPUT_IT> mapper,
-                   Functions::ReduceFunc<KEY, MAPPED_TYPE, REDUCED_TYPE> reducer);
+    template <class KEY = Deprecated,
+              class MAPPED_TYPE = Deprecated,
+              class REDUCED_TYPE = Deprecated,
+              class MAPPER_FUNC,
+              class REDUCER_FUNC,
+              class INPUT_IT,
+              class = Traits::IsInputIterator<INPUT_IT>>
+    auto mapReduceBatch(INPUT_IT first,
+                        size_t num,
+                        MAPPER_FUNC mapper,
+                        REDUCER_FUNC reducer)->
+          ThreadContextPtr<std::map<decltype(mappedKeyOf(mapper)), decltype(reducedTypeOf(reducer))>>;
 
     /// @brief Signal all threads to immediately terminate and exit. All other pending coroutines and IO tasks will not complete.
     ///        Call this function for a fast shutdown of the dispatcher.
@@ -325,9 +328,11 @@ public:
     
     /// @brief Drains all queues on this dispatcher object.
     /// @param[in] timeout Maximum time for this function to wait. Set to 0 to wait indefinitely until all queues drain.
+    /// @param[in] isFinal If set to true, the dispatcher will not allow any more processing after the drain completes.
     /// @note This function blocks until all coroutines and IO tasks have completed. During this time, posting
     ///       of new tasks is disabled unless they are posted from within an already executing coroutine.
-    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
+    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds::zero(),
+               bool isFinal = false);
     
     /// @brief Returns the number of underlying coroutine threads as specified in the constructor. If -1 was passed
     ///        than this number essentially indicates the number of cores.
@@ -379,9 +384,22 @@ private:
     
     struct DrainGuard
     {
-        DrainGuard(std::atomic_bool& drain) : _drain(drain) { _drain = true; }
-        ~DrainGuard() { _drain = false; }
+        DrainGuard(std::atomic_bool& drain,
+                   bool reactivate = true) :
+            _drain(drain),
+            _reactivate(reactivate)
+        {
+            _drain = true;
+        }
+        ~DrainGuard()
+        {
+            if (_reactivate)
+            {
+                _drain = false;
+            }
+        }
         std::atomic_bool& _drain;
+        bool              _reactivate;
     };
     
     //Members

--- a/quantum/util/impl/quantum_future_joiner_impl.h
+++ b/quantum/util/impl/quantum_future_joiner_impl.h
@@ -60,7 +60,7 @@ FutureJoiner<T>::join(ThreadContextTag, DISPATCHER& dispatcher, std::vector<type
 {
 #if (__cplusplus == 201103L)
     std::shared_ptr<std::vector<typename FUTURE<T>::Ptr>> containerPtr(new std::vector<typename FUTURE<T>::Ptr>(std::move(futures)));
-    return dispatcher.template postAsyncIo2<std::vector<T>>([containerPtr]()->std::vector<T>
+    return dispatcher.template postAsyncIo2([containerPtr]()->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(containerPtr->size());
@@ -71,7 +71,7 @@ FutureJoiner<T>::join(ThreadContextTag, DISPATCHER& dispatcher, std::vector<type
         return result;
     });
 #else
-    return dispatcher.template postAsyncIo2<std::vector<T>>([container{std::move(futures)}]()->std::vector<T>
+    return dispatcher.template postAsyncIo2([container{std::move(futures)}]()->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(container.size());
@@ -91,7 +91,7 @@ FutureJoiner<T>::join(CoroContextTag, DISPATCHER& dispatcher, std::vector<typena
 {
 #if (__cplusplus == 201103L)
     std::shared_ptr<std::vector<typename FUTURE<T>::Ptr>> containerPtr(new std::vector<typename FUTURE<T>::Ptr>(std::move(futures)));
-    return dispatcher.template post2<std::vector<T>>([containerPtr](VoidContextPtr ctx)->std::vector<T>
+    return dispatcher.template post2([containerPtr](VoidContextPtr ctx)->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(containerPtr->size());
@@ -102,7 +102,7 @@ FutureJoiner<T>::join(CoroContextTag, DISPATCHER& dispatcher, std::vector<typena
         return result;
     });
 #else
-    return dispatcher.template post2<std::vector<T>>([container{std::move(futures)}](VoidContextPtr ctx)->std::vector<T>
+    return dispatcher.template post2([container{std::move(futures)}](VoidContextPtr ctx)->std::vector<T>
     {
         std::vector<T> result;
         result.reserve(container.size());

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -51,16 +51,16 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     FUNC&& func,
     ARGS&&... args)
 {
-    _dispatcher.post2<int>(_controllerQueueId,
-                           false,
-                           singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
-                           nullptr,
-                           (int)IQueue::QueueId::Any,
-                           false,
-                           *this,
-                           SequenceKey(sequenceKey),
-                           std::forward<FUNC>(func),
-                           std::forward<ARGS>(args)...);
+    _dispatcher.post2(_controllerQueueId,
+                      false,
+                      singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                      nullptr,
+                      (int)IQueue::QueueId::Any,
+                      false,
+                      *this,
+                      SequenceKey(sequenceKey),
+                      std::forward<FUNC>(func),
+                      std::forward<ARGS>(args)...);
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -79,16 +79,16 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
         throw std::runtime_error("Invalid IO queue id");
     }
 
-    _dispatcher.post2<int>(_controllerQueueId,
-                           false,
-                           singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
-                           std::move(opaque),
-                           std::move(queueId),
-                           std::move(isHighPriority),
-                           *this,
-                           SequenceKey(sequenceKey),
-                           std::forward<FUNC>(func),
-                           std::forward<ARGS>(args)...);
+    _dispatcher.post2(_controllerQueueId,
+                      false,
+                      singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                      std::move(opaque),
+                      std::move(queueId),
+                      std::move(isHighPriority),
+                      *this,
+                      SequenceKey(sequenceKey),
+                      std::forward<FUNC>(func),
+                      std::forward<ARGS>(args)...);
 }
  
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -99,16 +99,16 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     FUNC&& func,
     ARGS&&... args)
 {
-    _dispatcher.post2<int>(_controllerQueueId,
-                          false,
-                          multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
-                          nullptr,
-                          (int)IQueue::QueueId::Any,
-                          false,
-                          *this,
-                          std::vector<SequenceKey>(sequenceKeys),
-                          std::forward<FUNC>(func),
-                          std::forward<ARGS>(args)...);
+    _dispatcher.post2(_controllerQueueId,
+                      false,
+                      multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                      nullptr,
+                      (int)IQueue::QueueId::Any,
+                      false,
+                      *this,
+                      std::vector<SequenceKey>(sequenceKeys),
+                      std::forward<FUNC>(func),
+                      std::forward<ARGS>(args)...);
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -126,16 +126,16 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post2<int>(_controllerQueueId,
-                          false,
-                          multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
-                          std::move(opaque),
-                          std::move(queueId),
-                          std::move(isHighPriority),
-                          *this,
-                          std::vector<SequenceKey>(sequenceKeys),
-                          std::forward<FUNC>(func),
-                          std::forward<ARGS>(args)...);
+    _dispatcher.post2(_controllerQueueId,
+                      false,
+                      multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
+                      std::move(opaque),
+                      std::move(queueId),
+                      std::move(isHighPriority),
+                      *this,
+                      std::vector<SequenceKey>(sequenceKeys),
+                      std::forward<FUNC>(func),
+                      std::forward<ARGS>(args)...);
 }
  
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -143,15 +143,15 @@ template <class FUNC, class ... ARGS>
 void
 Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(FUNC&& func, ARGS&&... args)
 {
-    _dispatcher.post2<int>(_controllerQueueId,
-                          false,
-                          universalTaskScheduler<FUNC, ARGS...>,
-                          nullptr,
-                          (int)IQueue::QueueId::Any,
-                          false,
-                          *this,
-                          std::forward<FUNC>(func),
-                          std::forward<ARGS>(args)...);
+    _dispatcher.post2(_controllerQueueId,
+                      false,
+                      universalTaskScheduler<FUNC, ARGS...>,
+                      nullptr,
+                      (int)IQueue::QueueId::Any,
+                      false,
+                      *this,
+                      std::forward<FUNC>(func),
+                      std::forward<ARGS>(args)...);
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -168,15 +168,15 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post2<int>(_controllerQueueId,
-                          false,
-                          universalTaskScheduler<FUNC, ARGS...>,
-                          std::move(opaque),
-                          std::move(queueId),
-                          std::move(isHighPriority),
-                          *this,
-                          std::forward<FUNC>(func),
-                          std::forward<ARGS>(args)...);
+    _dispatcher.post2(_controllerQueueId,
+                      false,
+                      universalTaskScheduler<FUNC, ARGS...>,
+                      std::move(opaque),
+                      std::move(queueId),
+                      std::move(isHighPriority),
+                      *this,
+                      std::forward<FUNC>(func),
+                      std::forward<ARGS>(args)...);
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>

--- a/quantum/util/impl/quantum_util_impl.h
+++ b/quantum/util/impl/quantum_util_impl.h
@@ -207,7 +207,7 @@ std::vector<RET> Util::forEachCoro(VoidContextPtr ctx,
     for (size_t i = 0; i < num; ++i, ++inputIt)
     {
         //Run the function
-        asyncResults.emplace_back(ctx->template post2<RET>([inputIt, &func](VoidContextPtr ctx) mutable ->RET
+        asyncResults.emplace_back(ctx->template post2([inputIt, &func](VoidContextPtr ctx) mutable ->RET
         {
             return std::forward<FUNC>(func)(ctx, *inputIt);
         }));
@@ -237,7 +237,7 @@ Util::forEachBatchCoro(VoidContextPtr ctx,
         {
             break; //nothing to do
         }
-        asyncResults.emplace_back(ctx->template post2<std::vector<RET>>([inputIt, batchSize, &func](VoidContextPtr ctx) mutable ->std::vector<RET>
+        asyncResults.emplace_back(ctx->template post2([inputIt, batchSize, &func](VoidContextPtr ctx) mutable ->std::vector<RET>
         {
             std::vector<RET> result;
             result.reserve(batchSize);
@@ -273,7 +273,7 @@ Util::mapReduceCoro(VoidContextPtr ctx,
     using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
     
     // Map stage
-    IndexerInput indexerInput = ctx->template forEach<MapperOutput>(inputIt, num, mapper)->get(ctx);
+    IndexerInput indexerInput = ctx->forEach(inputIt, num, mapper)->get(ctx);
     
     // Index stage
     IndexerOutput indexerOutput;
@@ -285,7 +285,7 @@ Util::mapReduceCoro(VoidContextPtr ctx,
     }
     
     // Reduce stage
-    ReducedResults reducedResults = ctx->template forEach<ReducedResult>
+    ReducedResults reducedResults = ctx->forEach
         (indexerOutput.begin(), indexerOutput.size(), reducer)->get(ctx);
     
     ReducerOutput reducerOutput;
@@ -318,7 +318,7 @@ Util::mapReduceBatchCoro(VoidContextPtr ctx,
     using ReducerOutput = std::map<KEY, REDUCED_TYPE>;
     
     // Map stage
-    IndexerInput indexerInput = ctx->template forEachBatch<MapperOutput>(inputIt, num, mapper)->get(ctx);
+    IndexerInput indexerInput = ctx->forEachBatch(inputIt, num, mapper)->get(ctx);
     
     // Index stage
     IndexerOutput indexerOutput;
@@ -333,7 +333,7 @@ Util::mapReduceBatchCoro(VoidContextPtr ctx,
     }
     
     // Reduce stage
-    ReducedResults reducedResults = ctx->template forEachBatch<ReducedResult>
+    ReducedResults reducedResults = ctx->forEachBatch
         (indexerOutput.begin(), indexerOutput.size(), reducer)->get(ctx);
     
     ReducerOutput reducerOutput;


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
* Automatically deduce the return type for all callable objects passed to the library. This means that it is not longer required/needed to specify the return type as a template parameter when when posting jobs, making it easier and more intuitive. This applies to V1 and V1 APIs including `forEach` and `mapReduce` functions.
As an example:
```c++
 auto ctx = dispatcher.postFirst<int>([](CoroContext<int>::Ptr ctx)->int {
        return ctx->set(55); //declared type is int
    })->then<double>([](CoroContext<double>::Ptr ctx)->int {
        return ctx->set(22.33); //declared type is double
    })->then<std::string>([](CoroContext<std::string>::Ptr ctx)->int {
        return ctx->set("future"); //declared type is string
    })->then<std::list<int>>([](CoroContext<std::list<int>>::Ptr ctx)->int {
        return ctx->set(std::list<int>{1,2,3}); //declared type is list<int>
    })->end();
```
now becomes
```c++
auto ctx = dispatcher.postFirst([](CoroContext<int>::Ptr ctx)->int {
        return ctx->set(55); //deduced type is int
    })->then([](CoroContext<double>::Ptr ctx)->int {
        return ctx->set(22.33); //deduced type is double
    })->then([](CoroContext<std::string>::Ptr ctx)->int {
        return ctx->set("future"); //deduced type is string
    })->then([](CoroContext<std::list<int>>::Ptr ctx)->int {
        return ctx->set(std::list<int>{1,2,3}); //deduced type is list<int>
    })->end();
```
Notice that `post(), then()...` do not take template arguments anymore. Similarly for `forEach` or `mapReduce`:
```c++
    std::vector<int> start{0,1,2,3,4,5,6,7,8,9};
    std::vector<char> results = getDispatcher().forEach<char>(start.cbegin(), start.size(),
        [](VoidContextPtr, const int& val)->char {
        return 'a'+val;
    })->get();
```
becomes
```c++
    std::vector<int> start{0,1,2,3,4,5,6,7,8,9};
    std::vector<char> results = getDispatcher().forEach(start.cbegin(), start.size(),
        [](VoidContextPtr, const int& val)->char {
        return 'a'+val;
    })->get();
```

**Testing performed**
Compiled and ran unit tests

**Additional context**
1) Note that this change **is backwards compatible** and no code changes are needed. Going forward, new code can simply omit the template parameters
2) In the next major release, the template parameters marked with `Deprecated` **may** be removed to enforce simplicity, thus braking API.
