### PR TITLE
Added missing memory and tuple headers

### DIFF
--- a/quantum/quantum_traits.h
+++ b/quantum/quantum_traits.h
@@ -20,6 +20,8 @@
 #include <iterator>
 #include <type_traits>
 #include <vector>
+#include <tuple>
+#include <memory>
 
 namespace Bloomberg {
 namespace quantum {


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Added additional missing headers `memory` and `tuple` to compile on DTS-7
