### PR TITLE
Added drain functionality to the Sequencer

### DIFF
--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -19,6 +19,7 @@
 #include <quantum/quantum_context.h>
 #include <quantum/quantum_configuration.h>
 #include <quantum/quantum_macros.h>
+#include <quantum/util/quantum_drain_guard.h>
 #include <iterator>
 #include <chrono>
 
@@ -381,26 +382,6 @@ private:
     template <class RET, class FUNC, class ... ARGS>
     ThreadFuturePtr<RET>
     postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
-    
-    struct DrainGuard
-    {
-        DrainGuard(std::atomic_bool& drain,
-                   bool reactivate = true) :
-            _drain(drain),
-            _reactivate(reactivate)
-        {
-            _drain = true;
-        }
-        ~DrainGuard()
-        {
-            if (_reactivate)
-            {
-                _drain = false;
-            }
-        }
-        std::atomic_bool& _drain;
-        bool              _reactivate;
-    };
     
     //Members
     DispatcherCore              _dispatcher;

--- a/quantum/util/quantum_drain_guard.h
+++ b/quantum/util/quantum_drain_guard.h
@@ -1,0 +1,46 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_QUANTUM_DRAIN_GUARD_H
+#define BLOOMBERG_QUANTUM_DRAIN_GUARD_H
+
+namespace Bloomberg {
+namespace quantum {
+
+struct DrainGuard
+{
+    DrainGuard(std::atomic_bool& drain,
+               bool reactivate = true) :
+        _drain(drain),
+        _reactivate(reactivate)
+    {
+        _drain = true;
+    }
+    
+    ~DrainGuard()
+    {
+        if (_reactivate)
+        {
+            _drain = false;
+        }
+    }
+    std::atomic_bool& _drain;
+    bool              _reactivate;
+};
+
+}
+}
+
+#endif //BLOOMBERG_QUANTUM_DRAIN_GUARD_H

--- a/tests/quantum_sequencer_tests.cpp
+++ b/tests/quantum_sequencer_tests.cpp
@@ -148,7 +148,7 @@ TEST_P(SequencerTest, BasicTaskOrder)
         sequenceKeys[sequenceKey].push_back(id);
         sequencer.enqueue(sequenceKey, testData.makeTask(id));
     }
-    getDispatcher().drain();
+    sequencer.drain();
 
     EXPECT_EQ(testData.results().size(), (size_t)taskCount);
 
@@ -178,7 +178,7 @@ TEST_P(SequencerTest, TrimKeys)
         SequencerTestData::SequenceKey sequenceKey = id % sequenceKeyCount;
         sequencer.enqueue(sequenceKey, testData.makeTask(id));
     }
-    getDispatcher().drain();
+    sequencer.drain();
 
     EXPECT_EQ(sequencer.getSequenceKeyCount(), (size_t)sequenceKeyCount);
     EXPECT_EQ(sequencer.trimSequenceKeys(), 0u);
@@ -250,7 +250,7 @@ TEST_P(SequencerTest, ExceptionHandler)
             sequencer.enqueue(&sequenceKeys[id], (int)IQueue::QueueId::Any, false, sequenceKey, testData.makeTask(id));
         }
     }
-    getDispatcher().drain();
+    sequencer.drain();
 
     EXPECT_EQ(generatedExceptionCount, exceptionCallbackCallCount);
 }
@@ -328,7 +328,7 @@ TEST_P(SequencerTest, SequenceKeyStats)
         }
     }
 
-    getDispatcher().drain();
+    sequencer.drain();
 
     // check the final stats
     postedCount = 0;
@@ -344,9 +344,9 @@ TEST_P(SequencerTest, SequenceKeyStats)
     pendingCount += universalStatsAfter.getPendingTaskCount();
 
     EXPECT_EQ(sequenceKeyCount, (int)sequencer.getSequenceKeyCount());
-    EXPECT_EQ((unsigned int)taskCount, postedCount);
+    EXPECT_EQ((unsigned int)taskCount, postedCount-1); //-1 for drain()
     EXPECT_EQ(0u, pendingCount);
-    EXPECT_EQ(taskCount, (int)sequencer.getTaskStatistics().getPostedTaskCount());
+    EXPECT_EQ(taskCount, (int)sequencer.getTaskStatistics().getPostedTaskCount()-1); //-1 for drain()
     EXPECT_EQ(0u, sequencer.getTaskStatistics().getPendingTaskCount());
 }
 
@@ -379,7 +379,7 @@ TEST_P(SequencerTest, TaskOrderWithUniversal)
             sequencer.enqueue(sequenceKey, testData.makeTask(id));
         }
     }
-    getDispatcher().drain();
+    sequencer.drain();
 
     EXPECT_EQ((int)testData.results().size(), taskCount);
     EXPECT_EQ((int)sequencer.getSequenceKeyCount(), sequenceKeyCount);
@@ -441,7 +441,7 @@ TEST_P(SequencerTest, MultiSequenceKeyTasks)
         // save the task id for this sequenceKey
         sequencer.enqueue(sequenceKeys, testData.makeTask(id));
     }
-    getDispatcher().drain();
+    sequencer.drain();
 
     EXPECT_EQ((int)testData.results().size(), taskCount);
     EXPECT_EQ((int)sequencer.getSequenceKeyCount(), sequenceKeyCount);
@@ -514,7 +514,7 @@ TEST_P(SequencerTest, CustomHashFunction)
         // enqueue the task with the real sequenceKey id
         sequencer.enqueue(std::move(sequenceKey), testData.makeTask(id));
     }
-    getDispatcher().drain();
+    sequencer.drain();
 
     EXPECT_EQ((int)testData.results().size(), taskCount);
     EXPECT_EQ((int)sequencer.getSequenceKeyCount(), restrictedSequenceKeyCount);

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <list>
 #include <memory>
+#include <functional>
 
 using namespace quantum;
 using ms = std::chrono::milliseconds;
@@ -150,6 +151,14 @@ int DummyIoTask(ThreadPromise<int>::Ptr promise)
     std::this_thread::sleep_for(ms(10));
     return 0;
 }
+
+struct Dummy
+{
+    int MemberCoro(CoroContext<std::string>::Ptr ctx)
+    {
+        return ctx->set("test");
+    }
+};
 
 #ifdef BOOST_USE_VALGRIND
     int fibInput = 10;


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Added a `drain()` member function to the `Sequencer` class which is identical in signature to `Dispatcher::drain()`. While draining can be done directly from the dispatcher object itself, there are situations when the jobs enqueued in the Sequencer may post additional sub-jobs in the `Dispatcher`. If the `Dispatcher` drains, these jobs would fail since posting is disallowed while draining. By draining the `Sequencer` we allow all jobs to complete successfully. 

**Testing performed**
Ran unit tests and replaced `Dispatcher::drain()` with `Sequencer::drain()`
