### PR TITLE
Test fixture fixes

### DIFF
--- a/tests/quantum_fixture.h
+++ b/tests/quantum_fixture.h
@@ -111,6 +111,7 @@ public:
     
     void TearDown()
     {
+        _dispatcher->drain();
         _dispatcher = nullptr;
         //DispatcherSingleton::deleteInstances();
     }

--- a/tests/quantum_spinlocks_tests.cpp
+++ b/tests/quantum_spinlocks_tests.cpp
@@ -14,7 +14,6 @@
 ** limitations under the License.
 */
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <quantum/quantum.h>
 
 using namespace Bloomberg::quantum;

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -14,7 +14,6 @@
 ** limitations under the License.
 */
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <quantum_fixture.h>
 #include <vector>
 #include <set>


### PR DESCRIPTION
Signed-off-by: Denis Mindolin <dmindolin1@bloomberg.net>

*Issue number of the reported bug or feature request: #105*

**Describe your changes**
https://github.com/bloomberg/quantum/commit/10e480cd965be1b93d322e6f44f38b403c5938cb
introduced a bug in the DispatcherFixture::Teardown. Instead of deleting dispatcher, that method releases the pointer. However, if a test case doesn't drain the dispatcher, the tasks started by that test may be carried to the next test. And that's exactly the case why CheckCoroutineQueuing is failing: the previous test CheckNumThreads doesn't drain the dispatcher, and the very next CheckCoroutineQueuing  test case may count tasks from CheckNumThreads as completed resulting in stat mismatches and failing the test.

**Testing performed**
Run all the exiting tests

**Additional context**
Add any other context about your contribution here.
