### PR TITLE
Added check for buffer validity in the ContiguousPoolManager and fixe…

### DIFF
--- a/quantum/impl/quantum_contiguous_pool_manager_impl.h
+++ b/quantum/impl/quantum_contiguous_pool_manager_impl.h
@@ -82,6 +82,9 @@ void ContiguousPoolManager<T>::setBuffer(aligned_type *buffer, index_type size)
     }
     _control->_size = size;
     _control->_buffer = buffer;
+    if (_control->_freeBlocks) {
+        delete[] _control->_freeBlocks;
+    }
     _control->_freeBlocks = new index_type[size];
     if (!_control->_freeBlocks) {
         throw std::bad_alloc();
@@ -232,7 +235,7 @@ typename ContiguousPoolManager<T>::pointer ContiguousPoolManager<T>::bufferEnd()
 template <typename T>
 bool ContiguousPoolManager<T>::isManaged(pointer p)
 {
-    return (bufferStart() <= p) && (p < bufferEnd());
+    return !bufferStart() || (bufferStart() && (bufferStart() <= p) && (p < bufferEnd()));
 }
 
 template <typename T>

--- a/quantum/quantum_contiguous_pool_manager.h
+++ b/quantum/quantum_contiguous_pool_manager.h
@@ -131,10 +131,10 @@ private:
     std::shared_ptr<Control>  _control;
 };
 
-template <typename T, typename U>
+template <typename U, typename T>
 size_t resize(size_t t_size)
 {
-    return (t_size*sizeof(T))/sizeof(U);
+    return (t_size*sizeof(U))/sizeof(T);
 }
 
 }} //namespaces

--- a/quantum/quantum_heap_allocator.h
+++ b/quantum/quantum_heap_allocator.h
@@ -83,10 +83,10 @@ struct HeapAllocator : public ContiguousPoolManager<T>
     {}
     template <typename U>
     HeapAllocator(HeapAllocator<U>&& other) :
-        _size(std::min(_size, (index_type)resize<U,T>(other._size))),
+        ContiguousPoolManager<T>(std::move(other)),
+        _size((index_type)resize<U,T>(other._size)),
         _buffer(other._buffer)
     {
-        this->setBuffer(_buffer, _size);
         other._size = 0;
         other._buffer = nullptr;
     }

--- a/tests/quantum_fixture.h
+++ b/tests/quantum_fixture.h
@@ -106,14 +106,13 @@ public:
     void SetUp()
     {
         _dispatcher = &DispatcherSingleton::instance(GetParam());
+        _dispatcher->drain();
         _dispatcher->resetStats();
     }
     
     void TearDown()
     {
-        _dispatcher->drain();
         _dispatcher = nullptr;
-        //DispatcherSingleton::deleteInstances();
     }
 
     quantum::Dispatcher& getDispatcher()


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
* Added check for buffer validity in the `ContiguousPoolManager`
* Fixed move constructor of the `HeapPoolAllocator` class
* Moved `drain()` in tests to the Setup stage. 

**Testing performed**
Ran all unit tests + checked Valgrind to make sure there are no leaks.
