### PR TITLE
Fix drain issue when coroutine is still running

### DIFF
--- a/quantum/impl/quantum_contiguous_pool_manager_impl.h
+++ b/quantum/impl/quantum_contiguous_pool_manager_impl.h
@@ -134,6 +134,7 @@ template <typename T>
 typename ContiguousPoolManager<T>::pointer
 ContiguousPoolManager<T>::allocate(size_type n, const_pointer)
 {
+    assert(bufferStart());
     {
         SpinLock::Guard lock(_control->_spinlock);
         if (findContiguous(static_cast<index_type>(n)))
@@ -153,6 +154,7 @@ void ContiguousPoolManager<T>::deallocate(pointer p, size_type n)
     if (p == nullptr) {
         return;
     }
+    assert(bufferStart());
     if (isManaged(p)) {
         //find index of the block and return the individual blocks to the free pool
         SpinLock::Guard lock(_control->_spinlock);
@@ -235,7 +237,7 @@ typename ContiguousPoolManager<T>::pointer ContiguousPoolManager<T>::bufferEnd()
 template <typename T>
 bool ContiguousPoolManager<T>::isManaged(pointer p)
 {
-    return !bufferStart() || (bufferStart() && (bufferStart() <= p) && (p < bufferEnd()));
+    return (bufferStart() <= p) && (p < bufferEnd());
 }
 
 template <typename T>

--- a/quantum/impl/quantum_coroutine_pool_allocator_impl.h
+++ b/quantum/impl/quantum_coroutine_pool_allocator_impl.h
@@ -127,10 +127,12 @@ void CoroutinePoolAllocator<STACK_TRAITS>::deallocate(const boost::context::stac
 #if defined(BOOST_USE_VALGRIND)
     VALGRIND_STACK_DEREGISTER(ctx.valgrind_stack_id);
 #endif
+    int bi = blockIndex(ctx);
+    assert(bi >= -1 && bi < _size); //guard against coroutine stack overflow or corruption
     if (isManaged(ctx)) {
         //find index of the block
         SpinLock::Guard lock(_spinlock);
-        _freeBlocks[++_freeBlockIndex] = blockIndex(ctx);
+        _freeBlocks[++_freeBlockIndex] = bi;
     }
     else {
         delete[] (char*)getHeader(ctx);

--- a/quantum/quantum_contiguous_pool_manager.h
+++ b/quantum/quantum_contiguous_pool_manager.h
@@ -80,7 +80,7 @@ struct ContiguousPoolManager
     
     static ContiguousPoolManager
     select_on_container_copy_construction(const ContiguousPoolManager& other) {
-        return ContiguousPoolManager(other.size());
+        return ContiguousPoolManager(other);
     }
     bool operator==(const this_type& other) const {
         return _control && other._control && (_control->_buffer == other._control->_buffer);

--- a/tests/quantum_fixture.h
+++ b/tests/quantum_fixture.h
@@ -106,6 +106,7 @@ public:
     void SetUp()
     {
         _dispatcher = &DispatcherSingleton::instance(GetParam());
+        //Don't drain in the TearDown() because of the final CleanupTest::DeleteDispatcherInstance()
         _dispatcher->drain();
         _dispatcher->resetStats();
     }

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -1488,7 +1488,7 @@ TEST(SharedQueueTest, PerformanceTest1)
     {
         const TestConfiguration noCoroSharingConfig(false, false);
         quantum::Dispatcher& dispatcher = DispatcherSingleton::instance(noCoroSharingConfig);
-        
+        dispatcher.drain();
         auto start = std::chrono::steady_clock::now();
         enqueue_sleep_tasks(dispatcher, sleepTimes);
         dispatcher.drain();
@@ -1499,7 +1499,7 @@ TEST(SharedQueueTest, PerformanceTest1)
     {
         const TestConfiguration coroSharingConfig(false, true);
         quantum::Dispatcher& dispatcher = DispatcherSingleton::instance(coroSharingConfig);
-
+        dispatcher.drain();
         auto start = std::chrono::steady_clock::now();
         enqueue_sleep_tasks(dispatcher, sleepTimes);
         dispatcher.drain();


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
* Properly set the idle flag in the coroutine processing function to determine when a thread is still active. This could cause `drain()` not to wait fully if there was still one task executing.
* Added more asserts in the `ContiguousPoolAllocator` class to catch invalid states.

**Testing performed**
Ran unit tests. Also tested shutting down an application and made sure all resources used by the `Dispatcher` were cleaned.
