### PR TITLE
Overload all post member functions for V1 and V2 API

### DIFF
--- a/quantum/impl/quantum_context_impl.h
+++ b/quantum/impl/quantum_context_impl.h
@@ -103,9 +103,9 @@ const std::pair<int, int>& IThreadContext<RET>::getCoroQueueIdRangeForAny() cons
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-IThreadContext<RET>::then(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+IThreadContext<RET>::then(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template then<Ret>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
@@ -121,9 +121,9 @@ IThreadContext<RET>::then2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<declty
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-IThreadContext<RET>::onError(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+IThreadContext<RET>::onError(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template onError<Ret>(std::forward<FUNC>(func), std::forward<ARGS>(args)...);
 }
 
@@ -139,9 +139,9 @@ IThreadContext<RET>::onError2(FUNC&& func, ARGS&&... args)->ThreadContextPtr<dec
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-IThreadContext<RET>::finally(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+IThreadContext<RET>::finally(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template finally<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -263,9 +263,9 @@ const std::pair<int, int>& ICoroContext<RET>::getCoroQueueIdRangeForAny() const
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::post(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::post(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template post<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -284,9 +284,9 @@ ICoroContext<RET>::post2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(r
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template post<Ret>(
         queueId,
         isHighPriority,
@@ -310,9 +310,9 @@ ICoroContext<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&..
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::postFirst(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::postFirst(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template postFirst<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -332,9 +332,9 @@ ICoroContext<RET>::postFirst2(FUNC&& func, ARGS&&... args)->CoroContextPtr<declt
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template postFirst<Ret>(
         queueId,
         isHighPriority,
@@ -358,9 +358,9 @@ ICoroContext<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARG
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::then(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::then(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template then<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -380,9 +380,9 @@ ICoroContext<RET>::then2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(r
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::onError(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::onError(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template onError<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -402,9 +402,9 @@ ICoroContext<RET>::onError2(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltyp
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::finally(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(resultOf(func))>
+ICoroContext<RET>::finally(FUNC&& func, ARGS&&... args)->CoroContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template finally<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -432,9 +432,9 @@ ICoroContext<RET>::end()
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::postAsyncIo(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf(func))>
+ICoroContext<RET>::postAsyncIo(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(ioResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(ioResult(func));
     return static_cast<Impl*>(this)->template postAsyncIo<Ret>(
         std::forward<FUNC>(func),
         std::forward<ARGS>(args)...);
@@ -454,9 +454,9 @@ ICoroContext<RET>::postAsyncIo2(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decl
 template <class RET>
 template <class OTHER_RET, class FUNC, class ... ARGS>
 auto
-ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf(func))>
+ICoroContext<RET>::postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(ioResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(ioResult(func));
     return static_cast<Impl*>(this)->template postAsyncIo<Ret>(
         queueId,
         isHighPriority,
@@ -482,9 +482,9 @@ template <class OTHER_RET, class INPUT_IT, class FUNC, class>
 auto
 ICoroContext<RET>::forEach(INPUT_IT first,
                            INPUT_IT last,
-                           FUNC&& func)->CoroContextPtr<std::vector<decltype(resultOf2(func))>>
+                           FUNC&& func)->CoroContextPtr<std::vector<decltype(coroResult(func))>>
 {
-    using Ret = decltype(resultOf2(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template forEach<Ret>(first, last, std::forward<FUNC>(func));
 }
 
@@ -493,9 +493,9 @@ template <class OTHER_RET, class INPUT_IT, class FUNC>
 auto
 ICoroContext<RET>::forEach(INPUT_IT first,
                            size_t num,
-                           FUNC&& func)->CoroContextPtr<std::vector<decltype(resultOf2(func))>>
+                           FUNC&& func)->CoroContextPtr<std::vector<decltype(coroResult(func))>>
 {
-    using Ret = decltype(resultOf2(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template forEach<Ret>(first, num, std::forward<FUNC>(func));
 }
 
@@ -504,9 +504,9 @@ template <class OTHER_RET, class INPUT_IT, class FUNC, class>
 auto
 ICoroContext<RET>::forEachBatch(INPUT_IT first,
                                 INPUT_IT last,
-                                FUNC&& func)->CoroContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
+                                FUNC&& func)->CoroContextPtr<std::vector<std::vector<decltype(coroResult(func))>>>
 {
-    using Ret = decltype(resultOf2(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template forEachBatch<Ret>(first, last, std::forward<FUNC>(func));
 }
 
@@ -515,9 +515,9 @@ template <class OTHER_RET, class INPUT_IT, class FUNC>
 auto
 ICoroContext<RET>::forEachBatch(INPUT_IT first,
                                 size_t num,
-                                FUNC&& func)->CoroContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
+                                FUNC&& func)->CoroContextPtr<std::vector<std::vector<decltype(coroResult(func))>>>
 {
-    using Ret = decltype(resultOf2(func));
+    using Ret = decltype(coroResult(func));
     return static_cast<Impl*>(this)->template forEachBatch<Ret>(first, num, std::forward<FUNC>(func));
 }
 
@@ -830,31 +830,10 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::thenImpl(ITask::Type type, FUNC&& func, ARGS&&... args)
 {
+    using FirstArg = decltype(firstArgOf(func));
     auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*this),
                                      Context<OTHER_RET>::deleter);
-    auto task = Task::Ptr(new Task(ctx,
-                                   _task->getQueueId(),      //keep current queueId
-                                   _task->isHighPriority(),  //keep current priority
-                                   type,
-                                   std::forward<FUNC>(func),
-                                   std::forward<ARGS>(args)...),
-                          Task::deleter);
-    ctx->setTask(task);
-    
-    //Chain tasks
-    std::static_pointer_cast<ITaskContinuation>(_task)->setNextTask(task);
-    task->setPrevTask(std::static_pointer_cast<ITaskContinuation>(_task));
-    return ctx;
-}
-
-template <class RET>
-template <class OTHER_RET, class FUNC, class ... ARGS>
-ContextPtr<OTHER_RET>
-Context<RET>::thenImpl2(ITask::Type type, FUNC&& func, ARGS&&... args)
-{
-    auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*this),
-                                     Context<OTHER_RET>::deleter);
-    auto task = Task::Ptr(new Task(Void{},
+    auto task = Task::Ptr(new Task(Traits::IsVoidContext<FirstArg>{},
                                    ctx,
                                    _task->getQueueId(),      //keep current queueId
                                    _task->isHighPriority(),  //keep current priority
@@ -889,7 +868,7 @@ Context<RET>::then2(FUNC&& func, ARGS&&... args)
 {
     //Previous task must either be First or Continuation types
     validateTaskType(ITask::Type::Continuation);
-    return thenImpl2<OTHER_RET, FUNC, ARGS...>(ITask::Type::Continuation,
+    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::Continuation,
                                                std::forward<FUNC>(func),
                                                std::forward<ARGS>(args)...);
 }
@@ -911,7 +890,7 @@ ContextPtr<OTHER_RET>
 Context<RET>::onError2(FUNC&& func, ARGS&&... args)
 {
     validateTaskType(ITask::Type::ErrorHandler);
-    return thenImpl2<OTHER_RET, FUNC, ARGS...>(ITask::Type::ErrorHandler,
+    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::ErrorHandler,
                                                std::forward<FUNC>(func),
                                                std::forward<ARGS>(args)...);
 }
@@ -933,7 +912,7 @@ ContextPtr<OTHER_RET>
 Context<RET>::finally2(FUNC&& func, ARGS&&... args)
 {
     validateTaskType(ITask::Type::Final);
-    return thenImpl2<OTHER_RET, FUNC, ARGS...>(ITask::Type::Final,
+    return thenImpl<OTHER_RET, FUNC, ARGS...>(ITask::Type::Final,
                                                std::forward<FUNC>(func),
                                                std::forward<ARGS>(args)...);
 }
@@ -965,7 +944,7 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 Context<RET>::postAsyncIo2(FUNC&& func, ARGS&&... args)
 {
-    return postAsyncIoImpl2<OTHER_RET>((int)IQueue::QueueId::Any,
+    return postAsyncIoImpl<OTHER_RET>((int)IQueue::QueueId::Any,
                                        false,
                                        std::forward<FUNC>(func),
                                        std::forward<ARGS>(args)...);
@@ -987,7 +966,7 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 Context<RET>::postAsyncIo2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return postAsyncIoImpl2<OTHER_RET>(queueId,
+    return postAsyncIoImpl<OTHER_RET>(queueId,
                                        isHighPriority,
                                        std::forward<FUNC>(func),
                                        std::forward<ARGS>(args)...);
@@ -998,32 +977,13 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 CoroFuturePtr<OTHER_RET>
 Context<RET>::postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
+    using FirstArg = decltype(firstArgOf(func));
     if (queueId < (int)IQueue::QueueId::Any)
     {
         throw std::runtime_error("Invalid coroutine queue id");
     }
     auto promise = PromisePtr<OTHER_RET>(new Promise<OTHER_RET>(), Promise<OTHER_RET>::deleter);
-    auto task = IoTask::Ptr(new IoTask(promise,
-                                       queueId,
-                                       isHighPriority,
-                                       std::forward<FUNC>(func),
-                                       std::forward<ARGS>(args)...),
-                            IoTask::deleter);
-    _dispatcher->postAsyncIo(task);
-    return promise->getICoroFuture();
-}
-
-template <class RET>
-template <class OTHER_RET, class FUNC, class ... ARGS>
-CoroFuturePtr<OTHER_RET>
-Context<RET>::postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-{
-    if (queueId < (int)IQueue::QueueId::Any)
-    {
-        throw std::runtime_error("Invalid coroutine queue id");
-    }
-    auto promise = PromisePtr<OTHER_RET>(new Promise<OTHER_RET>(), Promise<OTHER_RET>::deleter);
-    auto task = IoTask::Ptr(new IoTask(Void{},
+    auto task = IoTask::Ptr(new IoTask(Traits::IsThreadPromise<FirstArg>{},
                                        promise,
                                        queueId,
                                        isHighPriority,
@@ -1397,7 +1357,7 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::post2(FUNC&& func, ARGS&&... args)
 {
-    return postImpl2<OTHER_RET>((int)IQueue::QueueId::Any,
+    return postImpl<OTHER_RET>((int)IQueue::QueueId::Any,
                                 false,
                                 ITask::Type::Standalone,
                                 std::forward<FUNC>(func),
@@ -1421,7 +1381,7 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::post2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return postImpl2<OTHER_RET>(queueId,
+    return postImpl<OTHER_RET>(queueId,
                                 isHighPriority,
                                 ITask::Type::Standalone,
                                 std::forward<FUNC>(func),
@@ -1446,7 +1406,7 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::postFirst2(FUNC&& func, ARGS&&... args)
 {
-    return postImpl2<OTHER_RET>((int)IQueue::QueueId::Any,
+    return postImpl<OTHER_RET>((int)IQueue::QueueId::Any,
                                 false,
                                 ITask::Type::First,
                                 std::forward<FUNC>(func),
@@ -1470,7 +1430,7 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::postFirst2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
 {
-    return postImpl2<OTHER_RET>(queueId,
+    return postImpl<OTHER_RET>(queueId,
                                 isHighPriority,
                                 ITask::Type::First,
                                 std::forward<FUNC>(func),
@@ -1482,39 +1442,14 @@ template <class OTHER_RET, class FUNC, class ... ARGS>
 ContextPtr<OTHER_RET>
 Context<RET>::postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args)
 {
+    using FirstArg = decltype(firstArgOf(func));
     if (queueId < (int)IQueue::QueueId::Same)
     {
         throw std::runtime_error("Invalid coroutine queue id");
     }
     auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*_dispatcher),
                                      Context<OTHER_RET>::deleter);
-    auto task = Task::Ptr(new Task(ctx,
-                                   (queueId == (int)IQueue::QueueId::Same) ? _task->getQueueId() : queueId,
-                                   isHighPriority,
-                                   type,
-                                   std::forward<FUNC>(func),
-                                   std::forward<ARGS>(args)...),
-                          Task::deleter);
-    ctx->setTask(task);
-    if (type == ITask::Type::Standalone)
-    {
-        _dispatcher->post(task);
-    }
-    return ctx;
-}
-
-template <class RET>
-template <class OTHER_RET, class FUNC, class ... ARGS>
-ContextPtr<OTHER_RET>
-Context<RET>::postImpl2(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args)
-{
-    if (queueId < (int)IQueue::QueueId::Same)
-    {
-        throw std::runtime_error("Invalid coroutine queue id");
-    }
-    auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*_dispatcher),
-                                     Context<OTHER_RET>::deleter);
-    auto task = Task::Ptr(new Task(Void{},
+    auto task = Task::Ptr(new Task(Traits::IsVoidContext<FirstArg>{},
                                    ctx,
                                    (queueId == (int)IQueue::QueueId::Same) ? _task->getQueueId() : queueId,
                                    isHighPriority,

--- a/quantum/impl/quantum_dispatcher_impl.h
+++ b/quantum/impl/quantum_dispatcher_impl.h
@@ -41,9 +41,9 @@ Dispatcher::~Dispatcher()
 template <class RET, class FUNC, class ... ARGS>
 auto
 Dispatcher::post(FUNC&& func,
-                 ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+                 ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return postImpl<Ret>((int)IQueue::QueueId::Any,
                          false,
                          ITask::Type::Standalone,
@@ -57,7 +57,7 @@ Dispatcher::post2(FUNC&& func,
                   ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
     using Ret = decltype(resultOf2(func));
-    return postImpl2<Ret>((int)IQueue::QueueId::Any,
+    return postImpl<Ret>((int)IQueue::QueueId::Any,
                           false,
                           ITask::Type::Standalone,
                           std::forward<FUNC>(func),
@@ -69,9 +69,9 @@ auto
 Dispatcher::post(int queueId,
                  bool isHighPriority,
                  FUNC&& func,
-                 ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+                 ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return postImpl<Ret>(queueId,
                          isHighPriority,
                          ITask::Type::Standalone,
@@ -87,7 +87,7 @@ Dispatcher::post2(int queueId,
                   ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
     using Ret = decltype(resultOf2(func));
-    return postImpl2<Ret>(queueId,
+    return postImpl<Ret>(queueId,
                           isHighPriority,
                           ITask::Type::Standalone,
                           std::forward<FUNC>(func),
@@ -97,9 +97,9 @@ Dispatcher::post2(int queueId,
 template <class RET, class FUNC, class ... ARGS>
 auto
 Dispatcher::postFirst(FUNC&& func,
-                      ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+                      ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return postImpl<Ret>((int)IQueue::QueueId::Any,
                          false, ITask::Type::First,
                          std::forward<FUNC>(func),
@@ -112,7 +112,7 @@ Dispatcher::postFirst2(FUNC&& func,
                        ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
     using Ret = decltype(resultOf2(func));
-    return postImpl2<Ret>((int)IQueue::QueueId::Any,
+    return postImpl<Ret>((int)IQueue::QueueId::Any,
                           false,
                           ITask::Type::First,
                           std::forward<FUNC>(func),
@@ -124,9 +124,9 @@ auto
 Dispatcher::postFirst(int queueId,
                       bool isHighPriority,
                       FUNC&& func,
-                      ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>
+                      ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(coroResult(func));
     return postImpl<Ret>(queueId,
                          isHighPriority,
                          ITask::Type::First,
@@ -142,7 +142,7 @@ Dispatcher::postFirst2(int queueId,
                        ARGS&&... args)->ThreadContextPtr<decltype(resultOf2(func))>
 {
     using Ret = decltype(resultOf2(func));
-    return postImpl2<Ret>(queueId,
+    return postImpl<Ret>(queueId,
                           isHighPriority,
                           ITask::Type::First,
                           std::forward<FUNC>(func),
@@ -152,9 +152,9 @@ Dispatcher::postFirst2(int queueId,
 template <class RET, class FUNC, class ... ARGS>
 auto
 Dispatcher::postAsyncIo(FUNC&& func,
-                        ARGS&&... args)->ThreadFuturePtr<decltype(resultOf(func))>
+                        ARGS&&... args)->ThreadFuturePtr<decltype(ioResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(ioResult(func));
     return postAsyncIoImpl<Ret>((int)IQueue::QueueId::Any,
                                 false,
                                 std::forward<FUNC>(func),
@@ -167,7 +167,7 @@ Dispatcher::postAsyncIo2(FUNC&& func,
                          ARGS&&... args)->ThreadFuturePtr<decltype(resultOf2(func))>
 {
     using Ret = decltype(resultOf2(func));
-    return postAsyncIoImpl2<Ret>((int)IQueue::QueueId::Any,
+    return postAsyncIoImpl<Ret>((int)IQueue::QueueId::Any,
                                  false, std::forward<FUNC>(func),
                                  std::forward<ARGS>(args)...);
 }
@@ -177,9 +177,9 @@ auto
 Dispatcher::postAsyncIo(int queueId,
                         bool isHighPriority,
                         FUNC&& func,
-                        ARGS&&... args)->ThreadFuturePtr<decltype(resultOf(func))>
+                        ARGS&&... args)->ThreadFuturePtr<decltype(ioResult(func))>
 {
-    using Ret = decltype(resultOf(func));
+    using Ret = decltype(ioResult(func));
     return postAsyncIoImpl<Ret>(queueId,
                                 isHighPriority,
                                 std::forward<FUNC>(func),
@@ -194,7 +194,7 @@ Dispatcher::postAsyncIo2(int queueId,
                          ARGS&&... args)->ThreadFuturePtr<decltype(resultOf2(func))>
 {
     using Ret = decltype(resultOf2(func));
-    return postAsyncIoImpl2<Ret>(queueId,
+    return postAsyncIoImpl<Ret>(queueId,
                                  isHighPriority,
                                  std::forward<FUNC>(func),
                                  std::forward<ARGS>(args)...);
@@ -204,7 +204,7 @@ template <class RET, class INPUT_IT, class FUNC, class>
 auto
 Dispatcher::forEach(INPUT_IT first,
                     INPUT_IT last,
-                    FUNC&& func)->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>
+                    FUNC&& func)->ThreadContextPtr<std::vector<decltype(coroResult(func))>>
 {
     return forEach(first, std::distance(first, last), std::forward<FUNC>(func));
 }
@@ -213,9 +213,9 @@ template <class RET, class INPUT_IT, class FUNC>
 auto
 Dispatcher::forEach(INPUT_IT first,
                     size_t num,
-                    FUNC&& func)->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>
+                    FUNC&& func)->ThreadContextPtr<std::vector<decltype(coroResult(func))>>
 {
-    using Ret = decltype(resultOf2(func));
+    using Ret = decltype(coroResult(func));
     return post2(Util::forEachCoro<Ret, INPUT_IT, FUNC&&>,
                  INPUT_IT{first},
                  size_t{num},
@@ -226,7 +226,7 @@ template <class RET, class INPUT_IT, class FUNC, class>
 auto
 Dispatcher::forEachBatch(INPUT_IT first,
                          INPUT_IT last,
-                         FUNC&& func)->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
+                         FUNC&& func)->ThreadContextPtr<std::vector<std::vector<decltype(coroResult(func))>>>
 {
     return forEachBatch(first, std::distance(first, last), std::forward<FUNC>(func));
 }
@@ -235,9 +235,9 @@ template <class RET, class INPUT_IT, class FUNC>
 auto
 Dispatcher::forEachBatch(INPUT_IT first,
                          size_t num,
-                         FUNC&& func)->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>
+                         FUNC&& func)->ThreadContextPtr<std::vector<std::vector<decltype(coroResult(func))>>>
 {
-    using Ret = decltype(resultOf2(func));
+    using Ret = decltype(coroResult(func));
     return post2(Util::forEachBatchCoro<Ret, INPUT_IT, FUNC&&>,
                  INPUT_IT{first},
                  size_t{num},
@@ -422,6 +422,7 @@ Dispatcher::postImpl(int queueId,
                      FUNC&& func,
                      ARGS&&... args)
 {
+    using FirstArg = decltype(firstArgOf(func));
     if (_drain || _terminated)
     {
         throw std::runtime_error("Posting is disabled");
@@ -432,40 +433,7 @@ Dispatcher::postImpl(int queueId,
     }
     auto ctx = ContextPtr<RET>(new Context<RET>(_dispatcher),
                                Context<RET>::deleter);
-    auto task = Task::Ptr(new Task(ctx,
-                                   queueId,
-                                   isHighPriority,
-                                   type,
-                                   std::forward<FUNC>(func),
-                                   std::forward<ARGS>(args)...),
-                          Task::deleter);
-    ctx->setTask(task);
-    if (type == ITask::Type::Standalone)
-    {
-        _dispatcher.post(task);
-    }
-    return std::static_pointer_cast<IThreadContext<RET>>(ctx);
-}
-
-template <class RET, class FUNC, class ... ARGS>
-ThreadContextPtr<RET>
-Dispatcher::postImpl2(int queueId,
-                      bool isHighPriority,
-                      ITask::Type type,
-                      FUNC&& func,
-                      ARGS&&... args)
-{
-    if (_drain || _terminated)
-    {
-        throw std::runtime_error("Posting is disabled");
-    }
-    if (queueId < (int)IQueue::QueueId::Any)
-    {
-        throw std::runtime_error("Invalid coroutine queue id");
-    }
-    auto ctx = ContextPtr<RET>(new Context<RET>(_dispatcher),
-                               Context<RET>::deleter);
-    auto task = Task::Ptr(new Task(Void{},
+    auto task = Task::Ptr(new Task(Traits::IsVoidContext<FirstArg>{},
                                    ctx,
                                    queueId,
                                    isHighPriority,
@@ -488,6 +456,7 @@ Dispatcher::postAsyncIoImpl(int queueId,
                             FUNC&& func,
                             ARGS&&... args)
 {
+    using FirstArg = decltype(firstArgOf(func));
     if (_drain || _terminated)
     {
         throw std::runtime_error("Posting is disabled");
@@ -497,33 +466,7 @@ Dispatcher::postAsyncIoImpl(int queueId,
         throw std::runtime_error("Invalid IO queue id");
     }
     auto promise = PromisePtr<RET>(new Promise<RET>(), Promise<RET>::deleter);
-    auto task = IoTask::Ptr(new IoTask(promise,
-                                       queueId,
-                                       isHighPriority,
-                                       std::forward<FUNC>(func),
-                                       std::forward<ARGS>(args)...),
-                            IoTask::deleter);
-    _dispatcher.postAsyncIo(task);
-    return promise->getIThreadFuture();
-}
-
-template <class RET, class FUNC, class ... ARGS>
-ThreadFuturePtr<RET>
-Dispatcher::postAsyncIoImpl2(int queueId,
-                             bool isHighPriority,
-                             FUNC&& func,
-                             ARGS&&... args)
-{
-    if (_drain || _terminated)
-    {
-        throw std::runtime_error("Posting is disabled");
-    }
-    if (queueId < (int)IQueue::QueueId::Any)
-    {
-        throw std::runtime_error("Invalid IO queue id");
-    }
-    auto promise = PromisePtr<RET>(new Promise<RET>(), Promise<RET>::deleter);
-    auto task = IoTask::Ptr(new IoTask(Void{},
+    auto task = IoTask::Ptr(new IoTask(Traits::IsThreadPromise<FirstArg>{},
                                        promise,
                                        queueId,
                                        isHighPriority,

--- a/quantum/impl/quantum_io_task_impl.h
+++ b/quantum/impl/quantum_io_task_impl.h
@@ -34,7 +34,8 @@ namespace quantum {
 #endif
 
 template <class RET, class FUNC, class ... ARGS>
-IoTask::IoTask(std::shared_ptr<Promise<RET>> promise,
+IoTask::IoTask(std::true_type,
+               std::shared_ptr<Promise<RET>> promise,
                int queueId,
                bool isHighPriority,
                FUNC&& func,
@@ -47,7 +48,7 @@ IoTask::IoTask(std::shared_ptr<Promise<RET>> promise,
 }
 
 template <class RET, class FUNC, class ... ARGS>
-IoTask::IoTask(Void,
+IoTask::IoTask(std::false_type,
                std::shared_ptr<Promise<RET>> promise,
                int queueId,
                bool isHighPriority,

--- a/quantum/impl/quantum_stl_impl.h
+++ b/quantum/impl/quantum_stl_impl.h
@@ -78,6 +78,18 @@ namespace std {
 namespace Bloomberg {
 namespace quantum {
 
+template <size_t N, typename T, size_t S>
+struct TupleElement
+{
+    using Type = typename std::tuple_element<N, T>::type;
+};
+
+template <size_t N, typename T>
+struct TupleElement<N,T,0>
+{
+    using Type = void;
+};
+
 template <typename RET, typename = void>
 struct FunctionArguments;
 
@@ -85,7 +97,7 @@ template <typename RET, typename...ARGS>
 struct FunctionArguments<RET(*)(ARGS...)>
 {
     template <size_t N>
-    using ArgType = typename std::tuple_element<N, std::tuple<ARGS...>>::type;
+    using ArgType = typename TupleElement<N, std::tuple<ARGS...>, sizeof...(ARGS)>::Type;
     using RetType = RET;
 };
 

--- a/quantum/impl/quantum_task_impl.h
+++ b/quantum/impl/quantum_task_impl.h
@@ -35,7 +35,8 @@ namespace quantum {
 #endif
 
 template <class RET, class FUNC, class ... ARGS>
-Task::Task(std::shared_ptr<Context<RET>> ctx,
+Task::Task(std::false_type,
+           std::shared_ptr<Context<RET>> ctx,
            int queueId,
            bool isHighPriority,
            ITask::Type type,
@@ -53,7 +54,7 @@ Task::Task(std::shared_ptr<Context<RET>> ctx,
 {}
 
 template <class RET, class FUNC, class ... ARGS>
-Task::Task(Void,
+Task::Task(std::true_type,
            std::shared_ptr<Context<RET>> ctx,
            int queueId,
            bool isHighPriority,

--- a/quantum/interface/quantum_icoro_context.h
+++ b/quantum/interface/quantum_icoro_context.h
@@ -182,7 +182,7 @@ struct ICoroContext : ICoroContextBase
     /// @note This function is non-blocking and returns immediately. The returned context cannot be used to chain
     ///       further coroutines.
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto post(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+    auto post(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -209,7 +209,7 @@ struct ICoroContext : ICoroContextBase
     ///       further coroutines.
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
     auto post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-        ->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+        ->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -229,7 +229,7 @@ struct ICoroContext : ICoroContextBase
     /// @note This function is non-blocking and returns immediately. The returned context can be used to chain
     ///       further coroutines. Possible method calls following this are then(), onError(), finally() and end().
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto postFirst(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+    auto postFirst(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -256,7 +256,7 @@ struct ICoroContext : ICoroContextBase
     ///       further coroutines. Possible method calls following this are then(), onError(), finally() and end().
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
     auto postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-        ->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+        ->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -278,7 +278,7 @@ struct ICoroContext : ICoroContextBase
     ///       The returned context can be used to chain further coroutines. Possible method calls following this
     ///       are then(), onError(), finally() and end().
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto then(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+    auto then(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -302,7 +302,7 @@ struct ICoroContext : ICoroContextBase
     /// @note The function is non-blocking. The returned context can be used to chain further coroutines.
     ///       Possible method calls following this are finally() and end().
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto onError(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+    auto onError(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -322,7 +322,7 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine context object.
     /// @note This function is non-blocking and returns immediately. After this coroutine, the end() method must be called.
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto finally(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(resultOf(func))>::Ptr;
+    auto finally(FUNC&& func, ARGS&&... args)->typename ICoroContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -346,7 +346,7 @@ struct ICoroContext : ICoroContextBase
     /// @return A pointer to a coroutine future object which may be used to retrieve the result of the IO operation.
     /// @note This method does not block. The passed function will not be wrapped in a coroutine.
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto postAsyncIo(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(resultOf(func))>;
+    auto postAsyncIo(FUNC&& func, ARGS&&... args)->CoroFuturePtr<decltype(ioResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -370,7 +370,7 @@ struct ICoroContext : ICoroContextBase
     /// @note This method does not block. The passed function will not be wrapped in a coroutine.
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
     auto postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-        ->CoroFuturePtr<decltype(resultOf(func))>;
+        ->CoroFuturePtr<decltype(ioResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -396,7 +396,7 @@ struct ICoroContext : ICoroContextBase
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
     auto forEach(INPUT_IT first, INPUT_IT last, FUNC&& func)
-        ->typename ICoroContext<std::vector<decltype(resultOf2(func))>>::Ptr;
+        ->typename ICoroContext<std::vector<decltype(coroResult(func))>>::Ptr;
     
     /// @brief Same as forEach() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
@@ -404,7 +404,7 @@ struct ICoroContext : ICoroContextBase
               class INPUT_IT,
               class FUNC>
     auto forEach(INPUT_IT first, size_t num, FUNC&& func)
-        ->typename ICoroContext<std::vector<decltype(resultOf2(func))>>::Ptr;
+        ->typename ICoroContext<std::vector<decltype(coroResult(func))>>::Ptr;
     
     /// @brief The batched version of forEach(). This function applies the given unary function
     ///        to all the elements in the range [first,last). This function runs serially with respect
@@ -418,7 +418,7 @@ struct ICoroContext : ICoroContextBase
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
     auto forEachBatch(INPUT_IT first, INPUT_IT last, FUNC&& func)
-        ->typename ICoroContext<std::vector<std::vector<decltype(resultOf2(func))>>>::Ptr;
+        ->typename ICoroContext<std::vector<std::vector<decltype(coroResult(func))>>>::Ptr;
     
     /// @brief Same as forEachBatch() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
@@ -426,7 +426,7 @@ struct ICoroContext : ICoroContextBase
               class INPUT_IT,
               class FUNC>
     auto forEachBatch(INPUT_IT first, size_t num, FUNC&& func)
-        ->typename ICoroContext<std::vector<std::vector<decltype(resultOf2(func))>>>::Ptr;
+        ->typename ICoroContext<std::vector<std::vector<decltype(coroResult(func))>>>::Ptr;
     
     /// @brief Implementation of map-reduce functionality.
     /// @tparam KEY The KEY type used for mapping and reducing.
@@ -516,6 +516,8 @@ using VoidContextPtr = VoidCoroContextPtr; //shorthand version
 
 template <class RET>
 struct Traits::InnerType<std::shared_ptr<ICoroContext<RET>>> { using Type = RET;};
+template <>
+struct Traits::IsVoidContext<std::shared_ptr<ICoroContext<Void>>> : std::true_type {};
 
 }}
 

--- a/quantum/interface/quantum_ithread_context.h
+++ b/quantum/interface/quantum_ithread_context.h
@@ -188,7 +188,7 @@ struct IThreadContext : public IThreadContextBase
     ///       The returned context can be used to chain further functions. Possible method calls following this
     ///       are then(), onError(), finally() and end().
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto then(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf(func))>::Ptr;
+    auto then(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -211,7 +211,7 @@ struct IThreadContext : public IThreadContextBase
     /// @note The function is non-blocking. The returned context can be used to chain further functions.
     ///       Possible method calls following this are finally() and end().
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto onError(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf(func))>::Ptr;
+    auto onError(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
@@ -230,7 +230,7 @@ struct IThreadContext : public IThreadContextBase
     /// @param[in] args Variable list of arguments passed to the callable object.
     /// @note This function is non-blocking and returns immediately. After this function, the end() method must be called.
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>
-    auto finally(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(resultOf(func))>::Ptr;
+    auto finally(FUNC&& func, ARGS&&... args)->typename IThreadContext<decltype(coroResult(func))>::Ptr;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class OTHER_RET = Deprecated, class FUNC, class ... ARGS>

--- a/quantum/interface/quantum_ithread_promise.h
+++ b/quantum/interface/quantum_ithread_promise.h
@@ -82,7 +82,9 @@ template <class T>
 using ThreadPromisePtr = typename IThreadPromise<Promise,T>::Ptr;
 
 template <class T>
-struct Traits::InnerType<std::shared_ptr<IThreadPromise<Promise, T>>> { using Type = T;};
+struct Traits::InnerType<std::shared_ptr<IThreadPromise<Promise,T>>> { using Type = T;};
+template <class T>
+struct Traits::IsThreadPromise<std::shared_ptr<IThreadPromise<Promise,T>>> : std::true_type {};
 
 }}
 

--- a/quantum/quantum_context.h
+++ b/quantum/quantum_context.h
@@ -312,26 +312,14 @@ private:
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
     thenImpl(ITask::Type type, FUNC&& func, ARGS&&... args);
-    
-    template <class OTHER_RET, class FUNC, class ... ARGS>
-    typename Context<OTHER_RET>::Ptr
-    thenImpl2(ITask::Type type, FUNC&& func, ARGS&&... args);
 
     template <class OTHER_RET, class FUNC, class ... ARGS>
     typename Context<OTHER_RET>::Ptr
     postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
     
     template <class OTHER_RET, class FUNC, class ... ARGS>
-    typename Context<OTHER_RET>::Ptr
-    postImpl2(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
-    
-    template <class OTHER_RET, class FUNC, class ... ARGS>
     CoroFuturePtr<OTHER_RET>
     postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
-    
-    template <class OTHER_RET, class FUNC, class ... ARGS>
-    CoroFuturePtr<OTHER_RET>
-    postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     int index(int num) const;
     

--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -60,7 +60,7 @@ public:
     /// @note This function is non-blocking and returns immediately. The returned thread context cannot be used to chain
     ///       further coroutines.
     template <class RET = Deprecated, class FUNC, class ... ARGS>
-    auto post(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>;
+    auto post(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class RET = Deprecated, class FUNC, class ... ARGS>
@@ -84,7 +84,7 @@ public:
     ///       further coroutines.
     template <class RET = Deprecated, class FUNC, class ... ARGS>
     auto post(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-        ->ThreadContextPtr<decltype(resultOf(func))>;
+        ->ThreadContextPtr<decltype(coroResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class RET = Deprecated, class FUNC, class ... ARGS>
@@ -103,7 +103,7 @@ public:
     /// @note This function is non-blocking and returns immediately. The returned context can be used to chain other
     ///       coroutines which will run sequentially.
     template <class RET = Deprecated, class FUNC, class ... ARGS>
-    auto postFirst(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(resultOf(func))>;
+    auto postFirst(FUNC&& func, ARGS&&... args)->ThreadContextPtr<decltype(coroResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class RET = Deprecated, class FUNC, class ... ARGS>
@@ -127,7 +127,7 @@ public:
     ///       coroutines which will run sequentially.
     template <class RET = Deprecated, class FUNC, class ... ARGS>
     auto postFirst(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-        ->ThreadContextPtr<decltype(resultOf(func))>;
+        ->ThreadContextPtr<decltype(coroResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler coroutine signature (see documentation).
     template <class RET = Deprecated, class FUNC, class ... ARGS>
@@ -145,7 +145,7 @@ public:
     /// @return A pointer to a thread future object.
     /// @note This function is non-blocking and returns immediately. The passed function will not be wrapped in a coroutine.
     template <class RET = Deprecated, class FUNC, class ... ARGS>
-    auto postAsyncIo(FUNC&& func, ARGS&&... args)->ThreadFuturePtr<decltype(resultOf(func))>;
+    auto postAsyncIo(FUNC&& func, ARGS&&... args)->ThreadFuturePtr<decltype(ioResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
     template <class RET = Deprecated, class FUNC, class ... ARGS>
@@ -167,7 +167,7 @@ public:
     /// @note This function is non-blocking and returns immediately. The passed function will not be wrapped in a coroutine.
     template <class RET = Deprecated, class FUNC, class ... ARGS>
     auto postAsyncIo(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args)
-        ->ThreadFuturePtr<decltype(resultOf(func))>;
+        ->ThreadFuturePtr<decltype(ioResult(func))>;
     
     /// @brief Version 2 of the API which supports a simpler IO task signature (see documentation).
     template <class RET = Deprecated, class FUNC, class ... ARGS>
@@ -193,7 +193,7 @@ public:
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
     auto forEach(INPUT_IT first, INPUT_IT last, FUNC&& func)
-        ->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>;
+        ->ThreadContextPtr<std::vector<decltype(coroResult(func))>>;
     
     /// @brief Same as forEach() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
@@ -201,7 +201,7 @@ public:
               class INPUT_IT,
               class FUNC>
     auto forEach(INPUT_IT first, size_t num, FUNC&& func)
-        ->ThreadContextPtr<std::vector<decltype(resultOf2(func))>>;
+        ->ThreadContextPtr<std::vector<decltype(coroResult(func))>>;
     
     /// @brief The batched version of forEach(). This function applies the given unary function
     ///        to all the elements in the range [first,last). This function runs serially with respect
@@ -215,7 +215,7 @@ public:
               class FUNC,
               class = Traits::IsInputIterator<INPUT_IT>>
     auto forEachBatch(INPUT_IT first, INPUT_IT last, FUNC&& func)
-        ->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>;
+        ->ThreadContextPtr<std::vector<std::vector<decltype(coroResult(func))>>>;
     
     /// @brief Same as forEachBatch() but takes a length as second argument in case INPUT_IT
     ///        is not a random access iterator.
@@ -223,7 +223,7 @@ public:
               class INPUT_IT,
               class FUNC>
     auto forEachBatch(INPUT_IT first, size_t num, FUNC&& func)
-        ->ThreadContextPtr<std::vector<std::vector<decltype(resultOf2(func))>>>;
+        ->ThreadContextPtr<std::vector<std::vector<decltype(coroResult(func))>>>;
     
     /// @brief Implementation of map-reduce functionality.
     /// @tparam KEY The KEY type used for mapping and reducing.
@@ -372,16 +372,8 @@ private:
     postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
     
     template <class RET, class FUNC, class ... ARGS>
-    ThreadContextPtr<RET>
-    postImpl2(int queueId, bool isHighPriority, ITask::Type type, FUNC&& func, ARGS&&... args);
-    
-    template <class RET, class FUNC, class ... ARGS>
     ThreadFuturePtr<RET>
     postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
-    
-    template <class RET, class FUNC, class ... ARGS>
-    ThreadFuturePtr<RET>
-    postAsyncIoImpl2(int queueId, bool isHighPriority, FUNC&& func, ARGS&&... args);
     
     //Members
     DispatcherCore              _dispatcher;

--- a/quantum/quantum_io_task.h
+++ b/quantum/quantum_io_task.h
@@ -38,14 +38,15 @@ public:
     using WeakPtr = std::weak_ptr<IoTask>;
     
     template <class RET, class FUNC, class ... ARGS>
-    IoTask(std::shared_ptr<Promise<RET>> promise,
+    IoTask(std::true_type,
+           std::shared_ptr<Promise<RET>> promise,
            int queueId,
            bool isHighPriority,
            FUNC&& func,
            ARGS&&... args);
     
     template <class RET, class FUNC, class ... ARGS>
-    IoTask(Void,
+    IoTask(std::false_type,
            std::shared_ptr<Promise<RET>> promise,
            int queueId,
            bool isHighPriority,

--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -50,7 +50,8 @@ public:
     using CoroLocalStorage = std::unordered_map<std::string, void*>;
     
     template <class RET, class FUNC, class ... ARGS>
-    Task(std::shared_ptr<Context<RET>> ctx,
+    Task(std::false_type t,
+         std::shared_ptr<Context<RET>> ctx,
          int queueId,
          bool isHighPriority,
          ITask::Type type,
@@ -58,7 +59,7 @@ public:
          ARGS&&... args);
     
     template <class RET, class FUNC, class ... ARGS>
-    Task(Void,
+    Task(std::true_type t,
          std::shared_ptr<Context<RET>> ctx,
          int queueId,
          bool isHighPriority,

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -58,7 +58,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     {
         throw std::runtime_error("Sequencer is disabled");
     }
-    _dispatcher.post2(_controllerQueueId,
+    _dispatcher.post(_controllerQueueId,
                       false,
                       singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
                       nullptr,
@@ -89,7 +89,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post2(_controllerQueueId,
+    _dispatcher.post(_controllerQueueId,
                       false,
                       singleSequenceKeyTaskScheduler<FUNC, ARGS...>,
                       std::move(opaque),
@@ -113,7 +113,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     {
         throw std::runtime_error("Sequencer is disabled");
     }
-    _dispatcher.post2(_controllerQueueId,
+    _dispatcher.post(_controllerQueueId,
                       false,
                       multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
                       nullptr,
@@ -144,7 +144,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post2(_controllerQueueId,
+    _dispatcher.post(_controllerQueueId,
                       false,
                       multiSequenceKeyTaskScheduler<FUNC, ARGS...>,
                       std::move(opaque),
@@ -165,7 +165,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(FUNC&& func, ARGS&
     {
         throw std::runtime_error("Sequencer is disabled");
     }
-    _dispatcher.post2(_controllerQueueId,
+    _dispatcher.post(_controllerQueueId,
                       false,
                       universalTaskScheduler<FUNC, ARGS...>,
                       nullptr,
@@ -194,7 +194,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(
     {
         throw std::runtime_error("Invalid IO queue id");
     }
-    _dispatcher.post2(_controllerQueueId,
+    _dispatcher.post(_controllerQueueId,
                       false,
                       universalTaskScheduler<FUNC, ARGS...>,
                       std::move(opaque),
@@ -221,7 +221,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::trimSequenceKeys()
         }
         return ctx->set(_contexts.size());
     };
-    return _dispatcher.post<size_t>(_controllerQueueId, true, std::move(trimFunc))->get();
+    return _dispatcher.post(_controllerQueueId, true, std::move(trimFunc))->get();
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -237,7 +237,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getStatistics(const SequenceK
         }
         return ctx->set(SequenceKeyStatistics(*ctxIt->second._stats));
     };
-    return _dispatcher.post<SequenceKeyStatistics>(_controllerQueueId, true, std::move(statsFunc))->get();
+    return _dispatcher.post(_controllerQueueId, true, std::move(statsFunc))->get();
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -262,7 +262,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getSequenceKeyCount()
     {
         return ctx->set(_contexts.size());
     };
-    return _dispatcher.post<size_t>(_controllerQueueId, true, std::move(statsFunc))->get();
+    return _dispatcher.post(_controllerQueueId, true, std::move(statsFunc))->get();
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -387,7 +387,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::singleSequenceKeyTaskSchedule
     sequencer._taskStats->incrementPendingTaskCount();
     
     // save the context as the last for this sequenceKey
-    contextIt->second._context = ctx->post<Void>(
+    contextIt->second._context = ctx->post(
             std::move(queueId),
             std::move(isHighPriority),
             waitForTwoDependents<FUNC, ARGS...>,
@@ -432,7 +432,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::multiSequenceKeyTaskScheduler
     sequencer._taskStats->incrementPostedTaskCount();
     sequencer._taskStats->incrementPendingTaskCount();
     
-    ICoroContextBasePtr newCtx = ctx->post<Void>(
+    ICoroContextBasePtr newCtx = ctx->post(
             std::move(queueId),
             std::move(isHighPriority),
             waitForDependents<FUNC, ARGS...>,
@@ -483,7 +483,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::universalTaskScheduler(
     sequencer._taskStats->incrementPendingTaskCount();
 
     // post the task and save the context as the last for the universal sequenceKey
-    sequencer._universalContext._context = ctx->post<Void>(
+    sequencer._universalContext._context = ctx->post(
             std::move(queueId),
             std::move(isHighPriority),
             waitForUniversalDependent<FUNC, ARGS...>,

--- a/tests/quantum_sequencer_tests.cpp
+++ b/tests/quantum_sequencer_tests.cpp
@@ -290,7 +290,7 @@ TEST_P(SequencerTest, SequenceKeyStats)
     };
     // this task will be done when all the tasks posted above
     // are scheduled because it's posted to the same controlQueueId
-    getDispatcher().post2(controlQueueId, false, halfWayDoneJob)->wait();
+    getDispatcher().post(controlQueueId, false, halfWayDoneJob)->wait();
 
     // make sure all the enqueued tasks are pending
     size_t postedCount = 0;


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
- Using SFINAE and automatic return value type deduction, overload all the `post` member functions (`post, postAsyncIo, postFirst, then, onError, finally`) to accept both V1 and V2 API. The application is not longer required to explicitly call `post2` functions in order to run V2 API functions and can use a single overload instead. 

Example:
```c++
//V1 API
auto func1 = [](CoroContextPtr<std::string> ctx)->int { return ctx->set("HelloWorld!"); }
//V2 API
auto func2 = [](VoidContextPtr)->std::string { return "HelloWorld!"; }

Dispatcher d;
d.post(func1); //ok
d.post(func2); //ok (use overload)
d.post2(func2); //still ok (kept for backward compatibility)
```
_NOTE_: `forEach, forEachBatch, mapReduce, mapReduceBatch` as well as the `Sequencer` class, still accept only V2 API.

**Testing performed**
Ran unit tests using overloaded dispatch functions.
