### PR TITLE
cls variable improvements

### DIFF
--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -70,6 +70,7 @@
 #include <quantum/quantum_thread_traits.h>
 #include <quantum/quantum_traits.h>
 #include <quantum/quantum_yielding_thread.h>
+#include <quantum/util/quantum_cls_guard.h>
 #include <quantum/util/quantum_drain_guard.h>
 #include <quantum/util/quantum_future_joiner.h>
 #include <quantum/util/quantum_sequence_key_statistics.h>

--- a/quantum/quantum_cls.h
+++ b/quantum/quantum_cls.h
@@ -29,11 +29,13 @@ namespace cls {
 ///       coroutine, a pointer to it will be allocated, set to nullptr, and a reference to the
 ///       pointer will be returned here for reading/writing. 
 ///       If the variable with the name @see key has already been created within the current
-///       coroutine, then a reference to the previously set pointer will be returned. 
+///       coroutine, then a reference to the previously set pointer will be returned.
+/// @note If the function is called outside of a coroutine, then the thread-local storage is
+///       used with the semantics described above.
 /// @note Upon the termination of the coroutine, the storage occupied by the coro-local-variable
 ///       pointers will be freed. It is up to the user of the API to free the actual variable
 ///       storage.
-    
+
 template <typename T>
 T*& variable(const std::string& key);
 

--- a/quantum/util/impl/quantum_cls_guard_impl.h
+++ b/quantum/util/impl/quantum_cls_guard_impl.h
@@ -18,24 +18,25 @@
 //##############################################################################################
 //#################################### IMPLEMENTATIONS #########################################
 //##############################################################################################
-#include <quantum/quantum_task_queue.h>
-#include <stdexcept>
+
+#include <quantum/quantum_cls.h>
 
 namespace Bloomberg {
 namespace quantum {
 namespace cls {
 
-template <typename T>
-T*& variable(const std::string& key)
+template<typename T>
+Guard<T>::Guard(const std::string& key, T* value) :
+    _storage(variable<T>(key)), 
+    _prev(_storage)
 {
-    // default thread local map to be used outside of coroutines
-    thread_local Task::CoroLocalStorage defaultStorage;
-    
-    Task* task = TaskQueue::getCurrentTask();
-    Task::CoroLocalStorage& storage = task ? task->getCoroLocalStorage() : defaultStorage;
-    
-    void** r = &storage.emplace(key, nullptr).first->second;
-    return *reinterpret_cast<T**>(r);
+    _storage = value;
 }
 
+template<typename T>
+Guard<T>::~Guard()
+{
+    _storage = _prev;
+}
+    
 }}}

--- a/quantum/util/quantum_cls_guard.h
+++ b/quantum/util/quantum_cls_guard.h
@@ -1,0 +1,59 @@
+/*
+** Copyright 2018 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_QUANTUM_CLS_GUARD_H
+#define BLOOMBERG_QUANTUM_CLS_GUARD_H
+
+#include <string>
+
+namespace Bloomberg {
+namespace quantum {
+namespace cls {
+
+//==============================================================================================
+//                                class Guard
+//==============================================================================================
+/// @class Guard
+/// @brief Class a guard for a coro-local-storage variable. Saves a coro-local-storage upon
+/// construction, and recovers it to the previous value upon destruction.
+/// @tparam T Type of variable
+template<typename T>
+class Guard
+{    
+public:
+    // @brief Constructs an instance of guard saving a value into a coro-local-storage variable.
+    // @param[in] key variable name
+    // @param[in] value value to be saved to the variable with the name @see key
+    Guard(const std::string& key, T* value);
+    // @brief Destroys the guard instance recoving the previous variable value
+    ~Guard();
+
+    Guard() = delete;
+    Guard(const Guard&) = delete;
+    Guard(Guard&&) = delete;
+    
+    Guard& operator = (const Guard&) = delete;
+    Guard& operator = (Guard&&) = delete;
+
+private:
+    T*& _storage;       // storage for the variable
+    T*  _prev;          // previous variable value
+};
+    
+}}}
+
+#include <quantum/util/impl/quantum_cls_guard_impl.h>
+
+#endif //BLOOMBERG_QUANTUM_CLS_GUARD_H


### PR DESCRIPTION
Signed-off-by: Denis Mindolin <dmindolin1@bloomberg.net>

**Describe your changes**
1) Got rid of the exception throwing code in cls::variable by using thread_local when the function is called outside of a coroutine
2) Added cls::Guard for cls variable management.

**Testing performed**
Ran existing tests + added a test for cls::Guard.

**Additional context**
Add any other context about your contribution here.
