### PR TITLE
Added access to the coroutine context from within any function call.

### DIFF
--- a/quantum/impl/quantum_stl_impl.h
+++ b/quantum/impl/quantum_stl_impl.h
@@ -66,11 +66,11 @@ namespace std {
     using index_sequence_for = make_index_sequence<sizeof...(_Types)>;
 #endif
 #if (__cplusplus < 201703L)
-    template<class T, class U>
-    std::shared_ptr<T> reinterpret_pointer_cast(const std::shared_ptr<U>& r) noexcept
+    template<class TO, class FROM>
+    std::shared_ptr<TO> reinterpret_pointer_cast(const std::shared_ptr<FROM>& from) noexcept
     {
-        auto p = reinterpret_cast<typename std::shared_ptr<T>::element_type*>(r.get());
-        return std::shared_ptr<T>(r, p);
+        auto to = reinterpret_cast<typename std::shared_ptr<TO>::element_type*>(from.get());
+        return std::shared_ptr<TO>(from, to);
     }
 #endif
 } //std

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -43,7 +43,7 @@
 #include <quantum/quantum_allocator_traits.h>
 #include <quantum/quantum_buffer.h>
 #include <quantum/quantum_capture.h>
-#include <quantum/quantum_cls.h>
+#include <quantum/quantum_local.h>
 #include <quantum/quantum_condition_variable.h>
 #include <quantum/quantum_configuration.h>
 #include <quantum/quantum_context.h>
@@ -70,7 +70,7 @@
 #include <quantum/quantum_thread_traits.h>
 #include <quantum/quantum_traits.h>
 #include <quantum/quantum_yielding_thread.h>
-#include <quantum/util/quantum_cls_guard.h>
+#include <quantum/util/quantum_local_variable_guard.h>
 #include <quantum/util/quantum_drain_guard.h>
 #include <quantum/util/quantum_future_joiner.h>
 #include <quantum/util/quantum_sequence_key_statistics.h>

--- a/quantum/quantum_functions.h
+++ b/quantum/quantum_functions.h
@@ -16,18 +16,13 @@
 #ifndef BLOOMBERG_QUANTUM_FUNCTIONS_H
 #define BLOOMBERG_QUANTUM_FUNCTIONS_H
 
+#include <quantum/quantum_traits.h>
 #include <functional>
 #include <vector>
 #include <iterator>
 
 namespace Bloomberg {
 namespace quantum {
-
-struct Void{};
-template <typename T>
-struct ICoroContext;
-using VoidCoroContextPtr = std::shared_ptr<ICoroContext<Void>>;
-using VoidContextPtr = VoidCoroContextPtr; //shorthand version
 
 //==============================================================================================
 //                                    struct Functions

--- a/quantum/quantum_local.h
+++ b/quantum/quantum_local.h
@@ -13,14 +13,15 @@
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
 */
-#ifndef BLOOMBERG_QUANTUM_CLS_H
-#define BLOOMBERG_QUANTUM_CLS_H
+#ifndef BLOOMBERG_QUANTUM_LOCAL_H
+#define BLOOMBERG_QUANTUM_LOCAL_H
 
+#include <quantum/quantum_traits.h>
 #include <string>
 
 namespace Bloomberg {
 namespace quantum {
-namespace cls {
+namespace local {
 
 /// @brief Accesses the pointer to a coro-local-variable
 /// @param[in] key the variable name
@@ -35,12 +36,15 @@ namespace cls {
 /// @note Upon the termination of the coroutine, the storage occupied by the coro-local-variable
 ///       pointers will be freed. It is up to the user of the API to free the actual variable
 ///       storage.
-
 template <typename T>
 T*& variable(const std::string& key);
 
+/// @brief Get the current coroutine context
+/// @return The coroutine context if this function is called inside a coroutine or null otherwise
+VoidContextPtr context();
+
 }}}
 
-#include <quantum/impl/quantum_cls_impl.h>
+#include <quantum/impl/quantum_local_impl.h>
 
-#endif //BLOOMBERG_QUANTUM_CLS_H
+#endif //BLOOMBERG_QUANTUM_LOCAL_H

--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -100,6 +100,7 @@ public:
 
     //Local storage accessors
     CoroLocalStorage& getCoroLocalStorage();
+    ITaskAccessor::Ptr getTaskAccessor() const;
 
     //===================================
     //           NEW / DELETE
@@ -142,7 +143,7 @@ private:
         std::atomic_int& _suspendedState;
     };
     
-    ITaskAccessor::Ptr          _ctx; //holds execution context
+    ITaskAccessor::Ptr          _coroContext; //holds execution context
     Traits::Coroutine           _coro; //the current runnable coroutine
     int                         _queueId;
     bool                        _isHighPriority;

--- a/quantum/quantum_traits.h
+++ b/quantum/quantum_traits.h
@@ -32,6 +32,11 @@ namespace quantum {
 template <class T, class ALLOCATOR = std::allocator<T>>
 class Buffer;
 class Deprecated;
+struct Void{};
+template <typename T>
+struct ICoroContext;
+using VoidCoroContextPtr = std::shared_ptr<ICoroContext<Void>>;
+using VoidContextPtr = VoidCoroContextPtr; //shorthand version
 
 //==============================================================================================
 //                                    struct Traits

--- a/quantum/util/impl/quantum_local_variable_guard_impl.h
+++ b/quantum/util/impl/quantum_local_variable_guard_impl.h
@@ -18,24 +18,25 @@
 //##############################################################################################
 //#################################### IMPLEMENTATIONS #########################################
 //##############################################################################################
-#include <quantum/quantum_task_queue.h>
-#include <stdexcept>
+
+#include <quantum/util/quantum_local_variable_guard.h>
 
 namespace Bloomberg {
 namespace quantum {
-namespace cls {
+namespace local {
 
-template <typename T>
-T*& variable(const std::string& key)
+template<typename T>
+VariableGuard<T>::VariableGuard(const std::string& key, T* value) :
+    _storage(variable<T>(key)), 
+    _prev(_storage)
 {
-    // default thread local map to be used outside of coroutines
-    thread_local Task::CoroLocalStorage defaultStorage;
-    
-    Task* task = TaskQueue::getCurrentTask();
-    Task::CoroLocalStorage& storage = task ? task->getCoroLocalStorage() : defaultStorage;
-    
-    void** r = &storage.emplace(key, nullptr).first->second;
-    return *reinterpret_cast<T**>(r);
+    _storage = value;
 }
 
+template<typename T>
+VariableGuard<T>::~VariableGuard()
+{
+    _storage = _prev;
+}
+    
 }}}

--- a/quantum/util/quantum_local_variable_guard.h
+++ b/quantum/util/quantum_local_variable_guard.h
@@ -13,39 +13,38 @@
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
 */
-#ifndef BLOOMBERG_QUANTUM_CLS_GUARD_H
-#define BLOOMBERG_QUANTUM_CLS_GUARD_H
+#ifndef BLOOMBERG_QUANTUM_LOCAL_VARIABLE_GUARD_H
+#define BLOOMBERG_QUANTUM_LOCAL_VARIABLE_GUARD_H
 
 #include <string>
 
 namespace Bloomberg {
 namespace quantum {
-namespace cls {
+namespace local {
 
 //==============================================================================================
-//                                class Guard
+//                                class VariableGuard
 //==============================================================================================
-/// @class Guard
+/// @class VariableGuard
 /// @brief Class a guard for a coro-local-storage variable. Saves a coro-local-storage upon
 /// construction, and recovers it to the previous value upon destruction.
 /// @tparam T Type of variable
 template<typename T>
-class Guard
+class VariableGuard
 {    
 public:
     // @brief Constructs an instance of guard saving a value into a coro-local-storage variable.
     // @param[in] key variable name
     // @param[in] value value to be saved to the variable with the name @see key
-    Guard(const std::string& key, T* value);
-    // @brief Destroys the guard instance recoving the previous variable value
-    ~Guard();
+    VariableGuard(const std::string& key, T* value);
+    // @brief Destroys the guard instance recovering the previous variable value
+    ~VariableGuard();
 
-    Guard() = delete;
-    Guard(const Guard&) = delete;
-    Guard(Guard&&) = delete;
-    
-    Guard& operator = (const Guard&) = delete;
-    Guard& operator = (Guard&&) = delete;
+    VariableGuard() = delete;
+    VariableGuard(const VariableGuard&) = delete;
+    VariableGuard(VariableGuard&&) = delete;
+    VariableGuard& operator = (const VariableGuard&) = delete;
+    VariableGuard& operator = (VariableGuard&&) = delete;
 
 private:
     T*& _storage;       // storage for the variable
@@ -54,6 +53,6 @@ private:
     
 }}}
 
-#include <quantum/util/impl/quantum_cls_guard_impl.h>
+#include <quantum/util/impl/quantum_local_variable_guard_impl.h>
 
-#endif //BLOOMBERG_QUANTUM_CLS_GUARD_H
+#endif //BLOOMBERG_QUANTUM_LOCAL_VARIABLE_GUARD_H


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
- Add access to the coroutine context from within any function. This allows to `yield`, `sleep` or call any `ICoroContext` API (such as creating new coroutines) if the function is invoked from a coroutine. 
- changed inner namespace `quantum::cls` to `quantum::local`.

**Testing performed**
Created specific GTEST for this scenario. 
