### PR TITLE
Changed default infinite timeout to be -1 instead of 0. 

### DIFF
--- a/quantum/interface/quantum_ithread_future_base.h
+++ b/quantum/interface/quantum_ithread_future_base.h
@@ -46,6 +46,7 @@ struct IThreadFutureBase
     
     /// @brief Waits for the future value up to a maximum 'timeMs' milliseconds.
     /// @param[in] timeMs The maximum amount of milliseconds to wait until the future value becomes ready.
+    ///                   Using -1 is equivalent to calling wait(). Other negative values will throw.
     /// @return 'ready' if value was posted before duration expired or 'timeout' otherwise.
     /// @note Blocks until the value is ready, until 'timeMs' duration expires or until an exception is thrown.
     virtual std::future_status waitFor(std::chrono::milliseconds timeMs) const = 0;

--- a/quantum/quantum_condition_variable.h
+++ b/quantum/quantum_condition_variable.h
@@ -131,6 +131,7 @@ public:
     /// @tparam PERIOD A std::ratio representing the tick period such as ticks per second.
     /// @param[in] mutex Mutex object which is locked by the current coroutine.
     /// @param[in] time Maximum duration for which to wait on this condition.
+    ///                 Using -1 is equivalent to calling wait(). Other negative values will throw.
     /// @return True if the mutex was acquired before 'time' expired or false otherwise.
     /// @note This function should be called from a regular thread not from a coroutine.
     template <class REP, class PERIOD>
@@ -145,6 +146,7 @@ public:
     /// @param[in] sync Pointer to a coroutine synchronization object.
     /// @param[in] mutex Mutex object which is locked by the current coroutine.
     /// @param[in] time Maximum duration for which to wait on this condition.
+    ///                 Using -1 is equivalent to calling wait(). Other negative values will throw.
     /// @return True if the mutex was acquired before 'time' expired or false otherwise.
     /// @note This function should be called from a coroutine.
     template <class REP, class PERIOD>
@@ -160,14 +162,19 @@ public:
     /// @code
     ///     while(!predicate())
     ///     {
-    ///         waitFor(mutex, time);
+    ///         if (!waitFor(mutex, time))
+    ///         {
+    ///             return predicate();
+    ///         }
     ///     }
+    ///     return true;
     /// @endcode
     /// @tparam REP An arithmetic type such as int or double representing the number of ticks.
     /// @tparam PERIOD A std::ratio representing the tick period such as ticks per second.
     /// @tparam PREDICATE Callable function type having the following signature 'bool f()'.
     /// @param[in] mutex Mutex object which is locked by the current coroutine.
     /// @param[in] time Maximum duration for which to wait on this condition.
+    ///                 Using -1 is equivalent to calling wait(). Other negative values will throw.
     /// @param[in] predicate Function or functor to be tested as exit condition of the endless while loop.
     /// @return True if the mutex was acquired before 'time' expired, otherwise the predicate result after timeout.
     /// @note This function should be called from a regular thread not from a coroutine.
@@ -184,8 +191,12 @@ public:
     /// @code
     ///     while(!predicate())
     ///     {
-    ///         waitFor(mutex, time);
+    ///         if (!waitFor(mutex, time))
+    ///         {
+    ///             return predicate();
+    ///         }
     ///     }
+    ///     return true;
     /// @endcode
     /// @tparam REP An arithmetic type such as int or double representing the number of ticks.
     /// @tparam PERIOD A std::ratio representing the tick period such as ticks per second.
@@ -193,6 +204,7 @@ public:
     /// @param[in] sync Pointer to a coroutine synchronization object.
     /// @param[in] mutex Mutex object which is locked by the current coroutine.
     /// @param[in] time Maximum duration for which to wait on this condition.
+    ///                 Using -1 is equivalent to calling wait(). Other negative values will throw.
     /// @param[in] predicate Function or functor to be tested as exit condition of the endless while loop.
     /// @return True if the mutex was acquired before 'time' expired, otherwise the predicate result after timeout.
     /// @note This function should be called from a coroutine.
@@ -218,7 +230,7 @@ private:
     template <class REP, class PERIOD>
     bool waitForImpl(ICoroSync::Ptr sync,
                      Mutex& mutex,
-                     std::chrono::duration<REP, PERIOD>& time);
+                     const std::chrono::duration<REP, PERIOD>& time);
     
     template <class REP, class PERIOD, class PREDICATE = bool()>
     bool waitForImpl(ICoroSync::Ptr sync,

--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -328,11 +328,11 @@ public:
                int queueId = (int)IQueue::QueueId::All) const;
     
     /// @brief Drains all queues on this dispatcher object.
-    /// @param[in] timeout Maximum time for this function to wait. Set to 0 to wait indefinitely until all queues drain.
+    /// @param[in] timeout Maximum time for this function to wait. Set to -1 to wait indefinitely until all queues drain.
     /// @param[in] isFinal If set to true, the dispatcher will not allow any more processing after the drain completes.
     /// @note This function blocks until all coroutines and IO tasks have completed. During this time, posting
     ///       of new tasks is disabled unless they are posted from within an already executing coroutine.
-    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds::zero(),
+    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
                bool isFinal = false);
     
     /// @brief Returns the number of underlying coroutine threads as specified in the constructor. If -1 was passed

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -535,7 +535,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::canTrimContext(const ICoroCon
                                                                   const ICoroContextBasePtr& ctxToValidate)
 {
     return !ctxToValidate || !ctxToValidate->valid() ||
-           ctxToValidate->waitFor(ctx, std::chrono::milliseconds(0)) == std::future_status::ready;
+           ctxToValidate->waitFor(ctx, std::chrono::milliseconds::zero()) == std::future_status::ready;
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -544,7 +544,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::isPendingContext(const ICoroC
                                                                     const ICoroContextBasePtr& ctxToValidate)
 {
     return ctxToValidate && ctxToValidate->valid() &&
-           ctxToValidate->waitFor(ctx, std::chrono::milliseconds(0)) == std::future_status::timeout;
+           ctxToValidate->waitFor(ctx, std::chrono::milliseconds::zero()) == std::future_status::timeout;
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
@@ -561,14 +561,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::drain(std::chrono::millisecon
     });
     
     DrainGuard guard(_drain, !isFinal);
-    if (timeout == std::chrono::milliseconds::zero())
-    {
-        future->wait();
-    }
-    else
-    {
-        future->waitFor(timeout);
-    }
+    future->waitFor(timeout);
 }
 
 

--- a/quantum/util/quantum_sequencer.h
+++ b/quantum/util/quantum_sequencer.h
@@ -228,13 +228,13 @@ public:
     SequenceKeyStatistics getTaskStatistics();
     
     /// @brief Drains all sequenced tasks.
-    /// @param[in] timeout Maximum time for this function to wait. Set to 0 to wait indefinitely until all sequences drain.
+    /// @param[in] timeout Maximum time for this function to wait. Set to -1 to wait indefinitely until all sequences drain.
     /// @param[in] isFinal If set to true, the sequencer will not allow any more processing after the drain completes.
     /// @note This function blocks until all sequences have completed. During this time, posting
     ///       of new tasks is disabled unless they are posted from within an already executing coroutine.
     ///       Since this function posts a task which will wait on all others, getStatistics().getPostedTaskCount()
     ///       will contain one extra count.
-    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds::zero(),
+    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
                bool isFinal = false);
 
 private:


### PR DESCRIPTION
### Changes
- Changed default infinite timeout to be `-1` instead of `0`. `0` behaves as if no timeout was specified i.e. times out immediately.
- Updated `ConditionVariable::waitFor()` to match more closely the STL behavior.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>