### PR TITLE
Correctly set writer in ReadWriteMutex::tryUpgradeToWrite(), add tests

### DIFF
--- a/quantum/impl/quantum_read_write_mutex_impl.h
+++ b/quantum/impl/quantum_read_write_mutex_impl.h
@@ -100,7 +100,12 @@ void ReadWriteMutex::upgradeToWrite(ICoroSync::Ptr sync)
 inline
 bool ReadWriteMutex::tryUpgradeToWrite()
 {
-    return _spinlock.tryUpgradeToWrite();
+    bool rc = _spinlock.tryUpgradeToWrite();
+    if (rc)
+    {
+        _taskId = local::taskId();
+    }
+    return rc;
 }
 
 inline
@@ -112,11 +117,9 @@ void ReadWriteMutex::unlockRead()
 inline
 void ReadWriteMutex::unlockWrite()
 {
-    if (_taskId != local::taskId()) {
-        //invalid operation
-        assert(false);
-    }
+    assert(_taskId == local::taskId());
     _taskId = TaskId{}; //reset the task id
+    
     _spinlock.unlockWrite();
 }
 


### PR DESCRIPTION
**Describe your changes**
Fixed a bug where ReadWriteMutex::tryUpgradeToWrite() did not properly set the write-lock owner, so unlockWrite() operations were asserting. Refined an existing assert to be easier to understand.

**Testing performed**
Added additional unit tests to verify this case.