### PR TITLE
Return error if drain fails

### DIFF
--- a/quantum/impl/quantum_dispatcher_impl.h
+++ b/quantum/impl/quantum_dispatcher_impl.h
@@ -352,7 +352,7 @@ bool Dispatcher::empty(IQueue::QueueType type,
 }
 
 inline
-void Dispatcher::drain(std::chrono::milliseconds timeout,
+bool Dispatcher::drain(std::chrono::milliseconds timeout,
                        bool isFinal)
 {
     DrainGuard guard(_drain, !isFinal);
@@ -364,7 +364,7 @@ void Dispatcher::drain(std::chrono::milliseconds timeout,
 
     if (timeout == std::chrono::milliseconds::zero())
     {
-        return; //skip draining
+        return true; //skip draining
     }
     
     auto start = std::chrono::steady_clock::now();
@@ -382,7 +382,7 @@ void Dispatcher::drain(std::chrono::milliseconds timeout,
             if (std::chrono::duration_cast<std::chrono::milliseconds>(present-start) > timeout)
             {
                 //timeout reached
-                break;
+                return false;
             }
         }
     }
@@ -391,6 +391,7 @@ void Dispatcher::drain(std::chrono::milliseconds timeout,
     std::lock_guard<std::mutex> guard(Util::LogMutex());
     std::cout << "All queues have drained." << std::endl;
 #endif
+    return true;
 }
 
 inline

--- a/quantum/quantum_dispatcher.h
+++ b/quantum/quantum_dispatcher.h
@@ -330,9 +330,10 @@ public:
     /// @brief Drains all queues on this dispatcher object.
     /// @param[in] timeout Maximum time for this function to wait. Set to -1 to wait indefinitely until all queues drain.
     /// @param[in] isFinal If set to true, the dispatcher will not allow any more processing after the drain completes.
+    /// @return True if everything drains before timeout, false otherwise.
     /// @note This function blocks until all coroutines and IO tasks have completed. During this time, posting
     ///       of new tasks is disabled unless they are posted from within an already executing coroutine.
-    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
+    bool drain(std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
                bool isFinal = false);
     
     /// @brief Returns the number of underlying coroutine threads as specified in the constructor. If -1 was passed

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -548,7 +548,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::isPendingContext(const ICoroC
 }
 
 template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
-void
+bool
 Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::drain(std::chrono::milliseconds timeout,
                                                          bool isFinal)
 {
@@ -561,7 +561,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::drain(std::chrono::millisecon
     });
     
     DrainGuard guard(_drain, !isFinal);
-    future->waitFor(timeout);
+    return future->waitFor(timeout) == std::future_status::ready;
 }
 
 

--- a/quantum/util/quantum_sequencer.h
+++ b/quantum/util/quantum_sequencer.h
@@ -230,11 +230,12 @@ public:
     /// @brief Drains all sequenced tasks.
     /// @param[in] timeout Maximum time for this function to wait. Set to -1 to wait indefinitely until all sequences drain.
     /// @param[in] isFinal If set to true, the sequencer will not allow any more processing after the drain completes.
+    /// @return True if everything drains before timeout, false otherwise.
     /// @note This function blocks until all sequences have completed. During this time, posting
     ///       of new tasks is disabled unless they are posted from within an already executing coroutine.
     ///       Since this function posts a task which will wait on all others, getStatistics().getPostedTaskCount()
     ///       will contain one extra count.
-    void drain(std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
+    bool drain(std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
                bool isFinal = false);
 
 private:


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

Return `true/false` to indicate drain status. 