### PR TITLE
ReadWriteLock upgradeToWrite fix for simultaneous upgrades.

### DIFF
--- a/quantum/impl/quantum_read_write_spinlock_impl.h
+++ b/quantum/impl/quantum_read_write_spinlock_impl.h
@@ -71,25 +71,25 @@ namespace quantum {
 inline
 void ReadWriteSpinLock::lockRead()
 {
-    SpinLockUtil::lockRead(_count);
+    SpinLockUtil::lockRead(_count, LockTraits::Attempt::Unlimited);
 }
 
 inline
 void ReadWriteSpinLock::lockWrite()
 {
-    SpinLockUtil::lockWrite(_count);
+    SpinLockUtil::lockWrite(_count, LockTraits::Attempt::Unlimited);
 }
 
 inline
 bool ReadWriteSpinLock::tryLockRead()
 {
-    return SpinLockUtil::lockRead(_count, true);
+    return SpinLockUtil::lockRead(_count, LockTraits::Attempt::Once);
 }
 
 inline
 bool ReadWriteSpinLock::tryLockWrite()
 {
-    return SpinLockUtil::lockWrite(_count, true);
+    return SpinLockUtil::lockWrite(_count, LockTraits::Attempt::Once);
 }
 
 inline
@@ -107,13 +107,19 @@ void ReadWriteSpinLock::unlockWrite()
 inline
 void ReadWriteSpinLock::upgradeToWrite()
 {
-    SpinLockUtil::upgradeToWrite(_count);
+    SpinLockUtil::upgradeToWrite(_count, LockTraits::Attempt::Unlimited);
 }
 
 inline
 bool ReadWriteSpinLock::tryUpgradeToWrite()
 {
-    return SpinLockUtil::upgradeToWrite(_count, true);
+    return SpinLockUtil::upgradeToWrite(_count, LockTraits::Attempt::Once);
+}
+
+inline
+bool ReadWriteSpinLock::tryUpgradeToWrite(bool& pendingUpgrade)
+{
+    return SpinLockUtil::upgradeToWrite(_count, pendingUpgrade, LockTraits::Attempt::Reentrant);
 }
 
 inline

--- a/quantum/impl/quantum_spinlock_impl.h
+++ b/quantum/impl/quantum_spinlock_impl.h
@@ -31,13 +31,13 @@ namespace quantum {
 inline
 void SpinLock::lock()
 {
-    SpinLockUtil::lockWrite(_flag);
+    SpinLockUtil::lockWrite(_flag, LockTraits::Attempt::Unlimited);
 }
 
 inline
 bool SpinLock::tryLock()
 {
-    return SpinLockUtil::lockWrite(_flag, true);
+    return SpinLockUtil::lockWrite(_flag, LockTraits::Attempt::Once);
 }
 
 inline

--- a/quantum/quantum_read_write_mutex.h
+++ b/quantum/quantum_read_write_mutex.h
@@ -194,6 +194,8 @@ public:
     };
 
 private:
+    bool tryUpgradeToWriteImpl(bool* pendingUpgrade);
+    
     // Members
     mutable ReadWriteSpinLock   _spinlock;
     mutable TaskId              _taskId;

--- a/quantum/quantum_read_write_spinlock.h
+++ b/quantum/quantum_read_write_spinlock.h
@@ -67,8 +67,11 @@ public:
     void upgradeToWrite();
     
     /// @brief Attempts to upgrade a reader lock to a writer lock. This operation never blocks.
+    /// @param pendingUpdate Use this overload when calling this function in a loop.
+    ///                      PendingUpdate must be initialized to 'false'.
     /// @return True if the lock operation succeeded, false otherwise.
     bool tryUpgradeToWrite();
+    bool tryUpgradeToWrite(bool& pendingUpdate);
     
     /// @bried Determines if this object is either read or write locked.
     /// @return True if locked, false otherwise.

--- a/quantum/quantum_spinlock_traits.h
+++ b/quantum/quantum_spinlock_traits.h
@@ -75,6 +75,11 @@ struct SpinLockTraits {
 //==============================================================================
 struct LockTraits
 {
+    enum class Attempt : uint8_t {
+        Once,         ///> Try to obtain lock once and return success of failure
+        Unlimited,    ///> Try until lock is obtained
+        Reentrant     ///> Try continuously but return on each iteration w/o blocking
+    };
     using TryToLock = std::try_to_lock_t;
     using AdoptLock = std::adopt_lock_t;
     using DeferLock = std::defer_lock_t;

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -373,12 +373,8 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::singleSequenceKeyTaskSchedule
         FUNC&& func,
         ARGS&&... args)
 {
-    // find the dependent
-    typename ContextMap::iterator contextIt = sequencer._contexts.find(sequenceKey);
-    if (contextIt == sequencer._contexts.end())
-    {
-        contextIt = sequencer._contexts.emplace(sequenceKey, SequenceKeyData()).first;
-    }
+    // find the dependent or create a new element
+    typename ContextMap::iterator contextIt = sequencer._contexts.emplace(sequenceKey, SequenceKeyData()).first;
     // update stats
     contextIt->second._stats->incrementPostedTaskCount();
     contextIt->second._stats->incrementPendingTaskCount();

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -1025,7 +1025,7 @@ TEST_P(PromiseTest, FutureTimeout)
     //check elapsed time
     size_t elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
     EXPECT_LT(elapsed, (size_t)300);
-    EXPECT_EQ(status, std::future_status::timeout);
+    EXPECT_EQ((int)status, (int)std::future_status::timeout);
 }
 
 TEST_P(PromiseTest, FutureWithoutTimeout)
@@ -1044,7 +1044,7 @@ TEST_P(PromiseTest, FutureWithoutTimeout)
     size_t elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
     EXPECT_GE(elapsed, (size_t)100);
     EXPECT_LT(elapsed, (size_t)300);
-    EXPECT_EQ(status, std::future_status::ready);
+    EXPECT_EQ((int)status, (int)std::future_status::ready);
 }
 
 TEST_P(PromiseTest, WaitForAllFutures)
@@ -1489,7 +1489,7 @@ TEST_P(FutureJoinerTest, JoinCoroFutures)
     EXPECT_EQ(output, std::vector<int>({0,1,2,3,4,5,6,7,8,9}));
 }
 
-TEST(SharedQueueTest, PerformanceTest1)
+TEST(SharedQueueTest, PerformanceTest)
 {
     // The code below enqueues 30 short tasks, then 1 large task, and then 30 short tasks.
     // The intuition is that in the shared-coro mode, while one thread is busy with the large task,


### PR DESCRIPTION
**Description**

If `ReadWriteLock::upgradeToWrite()` was called and there were more than one simultaneous upgrades occurring, the function would block indefinitely. This was caused by the underlying loop calling `tryUpgradeToLock()` not keeping upgrade state during iterations. 
This fix introduces a new overload `ReadWriteSpinlock::tryUpgradeToWrite(bool& pendingUpgrade)` which should be used if calling this in a loop. 

**Testing performed**
The previous tests only covered calling `ReadWriteSpinlock::upgradeToWrite()` which worked properly because it was not invoked inside a loop. The `ReadWriteMutex::upgradeToWrite()` calls it in a loop which was never actually tested. As a validation, running the new added test on the previous master branch blocks indefinitely which proves the fix is working correctly. 

Signed-off-by: Alexander Damian <adamian@bloomberg.net>

