### PR TITLE
Prevent some compiler optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,14 @@ before_script:
 
 script:
   - ulimit -c unlimited -S #enable core dumps
-  - cmake -DCMAKE-BUILD_TYPE=Debug -DQUANTUM_ENABLE_TESTS=ON -DQUANTUM_BOOST_USE_VALGRIND=ON -DCMAKE_INSTALL_PREFIX=tests -DGTEST_ROOT=googletest/install .
+  - >
+    cmake
+    -DCMAKE_VERBOSE_MAKEFILE=ON
+    -DCMAKE-BUILD_TYPE=RelWithDebInfo
+    -DCMAKE_INSTALL_PREFIX=tests
+    -DCMAKE_CXX_FLAGS_INIT='-Wall -Wextra -m64 -ftemplate-backtrace-limit=0 -faligned-new -O3'
+    -DCMAKE_CXX_STANDARD=$CXXSTANDARD
+    -DGTEST_ROOT=googletest/install .
+    -DQUANTUM_ENABLE_TESTS=ON
+    -DQUANTUM_BOOST_USE_VALGRIND=ON
   - make QuantumTests && ./tests/QuantumTests.Linux64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT CMAKE_CXX_COMPILER)
 endif()
 #Set the compiler if the CXX_STANDARD environment variable is not set
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
 endif()
 #Set compile flags if CXXFLAGS environment variable is not set
 if (NOT CMAKE_CXX_FLAGS)

--- a/quantum/util/quantum_spinlock_util.h
+++ b/quantum/util/quantum_spinlock_util.h
@@ -47,15 +47,14 @@ private:
     static void backoff(size_t& num);
     static void spinWaitWriter(std::atomic_uint32_t& flag);
     static void spinWaitReader(std::atomic_uint32_t& flag);
-    static void spinWaitUpgradedReader(std::atomic_uint32_t& flag);
     static void pauseCPU();
     //Bit manipulations
-    static constexpr uint32_t set(int16_t upgrades, int16_t owners);
-    static constexpr uint32_t add(uint32_t n, int16_t upgrade, int16_t owner);
+    static uint32_t set(int16_t upgrades, int16_t owners);
+    static uint32_t add(uint32_t n, int16_t upgrade, int16_t owner);
     //The high 16 bits
-    static constexpr int16_t upgrades(uint32_t n);
+    static int16_t upgrades(uint32_t n);
     //The low 16 bits. -1 indicates a single exclusive writer
-    static constexpr int16_t owners(uint32_t n);
+    static int16_t owners(uint32_t n);
     static constexpr uint32_t mask = 0x0000FFFF;
 };
 


### PR DESCRIPTION
**Describe your changes**

- Fix compiler optimizations and minor bugs caused by using -03
- Updated travis to build with RelWithDebInfo instead of Debug

**Notable bugs found**
- On `quantum_spinlock_util_impl.h:329` in `spinWaitWriter()` the closing parenthesis was in the wrong place.
-  In `lockRead, lockWrite and upgradeToWriteImpl` the check for `spinWaitReader` and `spinWaitWriter` was checking against `!= Attempt::Once` instead of `==Attempt::Unlimited`. When upgrading coroutines to write, the attempt is set to `Attempt::Reentrant` which was causing the coroutine to enter this spinwait loop. Since this spin wait loop does not yield the coroutine, the first coroutine being upgraded would take the lock, waiting for all other coroutine readers to either upgrade or release their read locks. However since all other coroutines could never run (because of the non-yield) this would result in a deadlock. Previous `upgradeToWrite` tests only involved scenarios with threads which did not have this problem. A different test using coroutines is now added to check proper behavior in both cases.  

Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Testing performed**
- Added more tests for coroutine synchronization for ReadWriteLocks.
