### PR TITLE
Ensure sequencer returns success when running tasks

### DIFF
--- a/quantum/impl/quantum_queue_statistics_impl.h
+++ b/quantum/impl/quantum_queue_statistics_impl.h
@@ -157,13 +157,12 @@ void QueueStatistics::incHighPriorityCount()
 inline
 void QueueStatistics::print(std::ostream& out) const
 {
-    out << "Num elemetns: " << _numElements << std::endl;
-    out << "Num queued: " << _errorCount << std::endl;
+    out << "Num active: " << _numElements << std::endl;
     out << "Num completed: " << _completedCount << std::endl;
     out << "Num shared completed: " << _sharedQueueCompletedCount << std::endl;
     out << "Num errors: " << _errorCount << std::endl;
     out << "Num shared errors: " << _sharedQueueErrorCount << std::endl;
-    out << "Num high priority count: " << _highPriorityCount << std::endl;
+    out << "Num high-priority count: " << _highPriorityCount << std::endl;
 }
 
 inline

--- a/quantum/interface/quantum_iqueue_statistics.h
+++ b/quantum/interface/quantum_iqueue_statistics.h
@@ -34,7 +34,7 @@ struct IQueueStatistics
     /// @brief Reset all the counters to 0.
     virtual void reset() = 0;
     
-    /// @brief Gets the current size of the queue
+    /// @brief Gets the current number of active coroutines on this queue.
     virtual size_t numElements() const = 0;
     
     /// @brief Increment this counter.

--- a/quantum/quantum_queue_statistics.h
+++ b/quantum/quantum_queue_statistics.h
@@ -81,12 +81,12 @@ public:
 
 private:
     std::atomic_size_t  _numElements;
-    size_t      _errorCount;
-    size_t      _sharedQueueErrorCount;
-    size_t      _completedCount;
-    size_t      _sharedQueueCompletedCount;
-    size_t      _postedCount;
-    size_t      _highPriorityCount;
+    size_t              _errorCount;
+    size_t              _sharedQueueErrorCount;
+    size_t              _completedCount;
+    size_t              _sharedQueueCompletedCount;
+    size_t              _postedCount;
+    size_t              _highPriorityCount;
 };
 
 }}

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -507,7 +507,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::callPosted(
     try
     {
         std::forward<FUNC>(func)(ctx, std::forward<ARGS>(args)...);
-        return ctx->set(Void{});
+        return 0;
     }
     catch (const Traits::CoroutineStackUnwind&) {
         //allow coroutine stack to unwind properly


### PR DESCRIPTION
**Describe your changes**
- Ensure sequencer returns success when running tasks
- Fix small printing error when displaying dispatcher stats

Signed-off-by: Alexander Damian <adamian@bloomberg.net>

