### PR TITLE
Alloc with MMAP

### DIFF
--- a/quantum/impl/quantum_task_queue_impl.h
+++ b/quantum/impl/quantum_task_queue_impl.h
@@ -92,7 +92,7 @@ TaskQueue::~TaskQueue()
 inline
 void TaskQueue::pinToCore(int coreId)
 {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__CYGWIN__)
     SetThreadAffinityMask(_thread->native_handle(), 1 << coreId);
 #else
     int cpuSetSize = sizeof(cpu_set_t);

--- a/quantum/quantum_dispatcher_core.h
+++ b/quantum/quantum_dispatcher_core.h
@@ -23,7 +23,7 @@
 #include <thread>
 #include <functional>
 #include <algorithm>
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <winbase.h>
 #else
 #include <pthread.h>

--- a/tests/quantum_sequencer_tests.cpp
+++ b/tests/quantum_sequencer_tests.cpp
@@ -133,7 +133,7 @@ TEST_P(SequencerTest, BasicTaskOrder)
 {
     using namespace Bloomberg::quantum;
 
-    const int taskCount = 100;
+    const int taskCount = 2000;
     const int sequenceKeyCount = 3;
     SequencerTestData testData;
     SequencerTestData::SequenceKeyMap sequenceKeys;


### PR DESCRIPTION
**Describe your changes**

- Use MMAP instead of heap for coroutine allocations
- Moved header block at the end of the stack

The motivation behind using `mmap()` on Linux (and the equivalent feature on Windows - not yet supported) is to allow for immediate memory reclaiming of the coroutine stack (quite large). If heap allocations are used, although the allocated memory is freed, the dynamic memory management algorithm will not return immediately these blocks to the system as they may be reused at a later date (for obvious performance reasons). If the system is very busy, these blocks may become fragmented and new coroutine stack allocations will again require further expansion from system memory (via sbrk() or mmap()) as large contiguous areas won't be necessarily available. The result is that the application's RSS keeps increasing even through all coroutines may have finished processing. 

`mmap()` is just as fast as a call to `new()` without the drawbacks of memory leakage. An alternative to using `mmap()` is to tinker with `mallopt()` `M_MMAP_THRESHOLD` and `M_TRIM_THRESHOLD` but it's not as reliable as `mmap()`. Furthermore, with `mmap()` we can now protect the lowest page of the coroutine stack (only for pre-allocated blocks) so that we may catch any stack overflows. These overflows are hard to debug and fail in very different (often confusing) ways. 
One reason for not pre-allocating one, single large contiguous block for all pre-allocated coroutines (rather than piece-meal) is to prevent trampling from one stack to another. Even with page protection, a function may somehow write beyond the 4096 byte range of protection and hit the next stack. This is easily reproducible. 

**Testing performed**
Ran entire test suite. Any coroutine allocation issues are sure to fail immediately.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>
