### PR TITLE
Refactored GenericFuture class using variants. Provide runtime check …

### DIFF
--- a/quantum/impl/quantum_context_impl.h
+++ b/quantum/impl/quantum_context_impl.h
@@ -730,7 +730,7 @@ void Context<RET>::validateTaskType(ITask::Type type) const
 {
     if (!_task)
     {
-        throw std::runtime_error("Invalid task pointer");
+        throw std::invalid_argument("Invalid task pointer");
     }
     
     bool isValid = true;
@@ -801,7 +801,9 @@ void Context<RET>::setYieldHandle(Traits::Yield& yield)
 template <class RET>
 Traits::Yield& Context<RET>::getYieldHandle()
 {
-    if (!_yield) throw std::runtime_error("Yield handle is null");
+    if (!_yield) {
+        throw std::runtime_error("Yield handle is null");
+    }
     return *_yield;
 }
 
@@ -988,7 +990,7 @@ Context<RET>::postAsyncIoImpl(int queueId, bool isHighPriority, FUNC&& func, ARG
     using FirstArg = decltype(firstArgOf(func));
     if (queueId < (int)IQueue::QueueId::Any)
     {
-        throw std::runtime_error("Invalid coroutine queue id");
+        throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(queueId));
     }
     auto promise = PromisePtr<OTHER_RET>(new Promise<OTHER_RET>(), Promise<OTHER_RET>::deleter);
     auto task = IoTask::Ptr(new IoTask(Traits::IsThreadPromise<FirstArg>{},
@@ -1456,7 +1458,7 @@ Context<RET>::postImpl(int queueId, bool isHighPriority, ITask::Type type, FUNC&
     using FirstArg = decltype(firstArgOf(func));
     if (queueId < (int)IQueue::QueueId::Same)
     {
-        throw std::runtime_error("Invalid coroutine queue id");
+        throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(queueId));
     }
     auto ctx = ContextPtr<OTHER_RET>(new Context<OTHER_RET>(*_dispatcher),
                                      Context<OTHER_RET>::deleter);

--- a/quantum/impl/quantum_contiguous_pool_manager_impl.h
+++ b/quantum/impl/quantum_contiguous_pool_manager_impl.h
@@ -47,7 +47,7 @@ ContiguousPoolManager<T>::ContiguousPoolManager(const ContiguousPoolManager<U>& 
 {
     if (!_control || !_control->_buffer)
     {
-        throw std::runtime_error("Invalid allocator.");
+        throw std::invalid_argument("Invalid allocator");
     }
     //normalize size of buffer
     index_type newSize = std::min(_control->_size, (index_type)resize<U,T>(_control->_size));
@@ -62,7 +62,7 @@ ContiguousPoolManager<T>::ContiguousPoolManager(ContiguousPoolManager<U>&& other
 {
     if (!_control || !_control->_buffer)
     {
-        throw std::runtime_error("Invalid allocator.");
+        throw std::invalid_argument("Invalid allocator");
     }
     //normalize size of buffer
     index_type newSize = std::min(_control->_size, (index_type)resize<U,T>(_control->_size));
@@ -77,10 +77,10 @@ void ContiguousPoolManager<T>::setBuffer(aligned_type *buffer, index_type size)
         throw std::bad_alloc();
     }
     if (!buffer) {
-        throw std::runtime_error("Null buffer");
+        throw std::invalid_argument("Null buffer");
     }
     if (size == 0) {
-        throw std::runtime_error("Invalid allocator pool size");
+        throw std::invalid_argument("Invalid allocator pool size of zero");
     }
     _control->_size = size;
     _control->_buffer = buffer;

--- a/quantum/impl/quantum_coroutine_pool_allocator_impl.h
+++ b/quantum/impl/quantum_coroutine_pool_allocator_impl.h
@@ -50,7 +50,7 @@ CoroutinePoolAllocator<STACK_TRAITS>::CoroutinePoolAllocator(index_type size) :
 {
     if ((_size == 0) || (_stackSize == 0))
     {
-        throw std::runtime_error("Invalid coroutine allocator size specification");
+        throw std::invalid_argument("Invalid coroutine allocator size of zero");
     }
     //Make sure the stack is a multiple of the system page size
     size_t remainder = _stackSize % traits::page_size();

--- a/quantum/impl/quantum_dispatcher_core_impl.h
+++ b/quantum/impl/quantum_dispatcher_core_impl.h
@@ -128,7 +128,7 @@ size_t DispatcherCore::size(IQueue::QueueType type,
     {
         if (queueId != (int)IQueue::QueueId::All)
         {
-            throw std::runtime_error("Cannot specify queue id");
+            throw std::invalid_argument("Cannot specify queue id when type is 'All'");
         }
         return coroSize((int)IQueue::QueueId::All) + ioSize((int)IQueue::QueueId::All);
     }
@@ -147,7 +147,7 @@ bool DispatcherCore::empty(IQueue::QueueType type,
     {
         if (queueId != (int)IQueue::QueueId::All)
         {
-            throw std::runtime_error("Cannot specify queue id");
+            throw std::invalid_argument("Cannot specify queue id when type is 'All'");
         }
         return coroEmpty((int)IQueue::QueueId::All) && ioEmpty((int)IQueue::QueueId::All);
     }
@@ -176,7 +176,7 @@ size_t DispatcherCore::coroSize(int queueId) const
     }
     else if ((queueId >= (int)_coroQueues.size()) || (queueId < 0))
     {
-        throw std::runtime_error("Invalid coroutine queue id");
+        throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(queueId));
     }
     return _coroQueues.at(queueId).size();
 }
@@ -198,7 +198,7 @@ bool DispatcherCore::coroEmpty(int queueId) const
     }
     else if ((queueId >= (int)_coroQueues.size()) || (queueId < 0))
     {
-        throw std::runtime_error("Invalid coroutine queue id");
+        throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(queueId));
     }
     return _coroQueues.at(queueId).empty();
 }
@@ -273,7 +273,7 @@ QueueStatistics DispatcherCore::stats(IQueue::QueueType type, int queueId)
     {
         if (queueId != (int)IQueue::QueueId::All)
         {
-            throw std::runtime_error("Cannot specify queue id");
+            throw std::invalid_argument("Cannot specify queue id when queue type is 'All'");
         }
         return coroStats((int)IQueue::QueueId::All) + ioStats((int)IQueue::QueueId::All);
     }
@@ -304,7 +304,7 @@ QueueStatistics DispatcherCore::coroStats(int queueId)
     {
         if ((queueId >= (int)_coroQueues.size()) || (queueId < 0))
         {
-            throw std::runtime_error("Invalid coroutine queue id");
+            throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(queueId));
         }
         return static_cast<const QueueStatistics&>(_coroQueues.at(queueId).stats());
     }
@@ -339,7 +339,7 @@ QueueStatistics DispatcherCore::ioStats(int queueId)
     {
         if ((queueId >= (int)_ioQueues.size()) || (queueId < 0))
         {
-            throw std::runtime_error("Invalid IO queue id");
+            throw std::invalid_argument(std::string{"Invalid IO queue id: "} + std::to_string(queueId));
         }
         return static_cast<const QueueStatistics&>(_ioQueues.at(queueId).stats());
     }
@@ -406,7 +406,7 @@ void DispatcherCore::post(Task::Ptr task)
     {
         if (task->getQueueId() >= (int)_coroQueues.size())
         {
-            throw std::runtime_error("Queue id out of bounds");
+            throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(task->getQueueId()));
         }
     }
     
@@ -449,7 +449,7 @@ void DispatcherCore::postAsyncIo(IoTask::Ptr task)
     {
         if (task->getQueueId() >= (int)_ioQueues.size())
         {
-            throw std::runtime_error("Queue id out of bounds");
+            throw std::out_of_range(std::string{"Invalid IO queue id: "} + std::to_string(task->getQueueId()));
         }
         
         //Run on specific queue

--- a/quantum/impl/quantum_dispatcher_impl.h
+++ b/quantum/impl/quantum_dispatcher_impl.h
@@ -440,7 +440,7 @@ Dispatcher::postImpl(int queueId,
     }
     if (queueId < (int)IQueue::QueueId::Any)
     {
-        throw std::runtime_error("Invalid coroutine queue id");
+        throw std::out_of_range(std::string{"Invalid coroutine queue id: "} + std::to_string(queueId));
     }
     auto ctx = ContextPtr<RET>(new Context<RET>(_dispatcher),
                                Context<RET>::deleter);
@@ -474,7 +474,7 @@ Dispatcher::postAsyncIoImpl(int queueId,
     }
     if (queueId < (int)IQueue::QueueId::Any)
     {
-        throw std::runtime_error("Invalid IO queue id");
+        throw std::out_of_range(std::string{"Invalid IO queue id: "} + std::to_string(queueId));
     }
     auto promise = PromisePtr<RET>(new Promise<RET>(), Promise<RET>::deleter);
     auto task = IoTask::Ptr(new IoTask(Traits::IsThreadPromise<FirstArg>{},

--- a/quantum/util/impl/quantum_sequencer_impl.h
+++ b/quantum/util/impl/quantum_sequencer_impl.h
@@ -88,7 +88,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     }
     if (queueId < (int)IQueue::QueueId::Any)
     {
-        throw std::runtime_error("Invalid IO queue id");
+        throw std::out_of_range(std::string{"Invalid IO queue id: "} + std::to_string(queueId));
     }
     _dispatcher.post(_controllerQueueId,
                       false,
@@ -143,7 +143,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueue(
     }
     if (queueId < (int)IQueue::QueueId::Any)
     {
-        throw std::runtime_error("Invalid IO queue id");
+        throw std::out_of_range(std::string{"Invalid IO queue id: "} + std::to_string(queueId));
     }
     _dispatcher.post(_controllerQueueId,
                       false,
@@ -193,7 +193,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAll(
     }
     if (queueId < (int)IQueue::QueueId::Any)
     {
-        throw std::runtime_error("Invalid IO queue id");
+        throw std::out_of_range(std::string{"Invalid IO queue id: "} + std::to_string(queueId));
     }
     _dispatcher.post(_controllerQueueId,
                       false,

--- a/tests/quantum_sequencer_tests.cpp
+++ b/tests/quantum_sequencer_tests.cpp
@@ -108,8 +108,9 @@ private: // methods
         std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
         do {
             ctx->sleep(std::chrono::milliseconds(1));
-            if (not error.empty())
+            if (not error.empty()) {
                 throw std::runtime_error(error);
+            }
         }
         while(blockFlag and *blockFlag);
         std::chrono::steady_clock::time_point endTime = std::chrono::steady_clock::now();


### PR DESCRIPTION
**Describe your changes**

- Refactored `GenericFuture` class using variants for C++17 only.
- Provide runtime check for inadvertent coroutine blocking. This will assert when a coroutine context is present and the application tries to execute a blocking call via the `GenericFuture` class.
- Provided better exception error messages.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>
