### PR TITLE
Allow generic futures to be accessed from coroutines and threads inte…

### DIFF
--- a/quantum/util/impl/quantum_generic_future_impl.h
+++ b/quantum/util/impl/quantum_generic_future_impl.h
@@ -18,11 +18,33 @@
 //##############################################################################################
 //#################################### IMPLEMENTATIONS #########################################
 //##############################################################################################
-#include <quantum/quantum_future_state.h>
 #include <quantum/quantum_local.h>
+#include <quantum/quantum_future.h>
+#include <quantum/quantum_context.h>
 
 namespace Bloomberg {
 namespace quantum {
+
+//Interface conversion helpers for allowing a thread context (or thread future)
+//to be used inside a coroutine and vice-versa.
+namespace cast {
+    template <typename T>
+    static CoroContextPtr<T> context(const ThreadContextPtr<T>& ctx) {
+        return std::static_pointer_cast<Context<T>>(ctx);
+    }
+    template <typename T>
+    static CoroFuturePtr<T> context(const ThreadFuturePtr<T>& ctx) {
+        return std::static_pointer_cast<Future<T>>(ctx);
+    }
+    template <typename T>
+    static ThreadContextPtr<T> context(const CoroContextPtr<T>& ctx) {
+        return std::static_pointer_cast<Context<T>>(ctx);
+    }
+    template <typename T>
+    static ThreadFuturePtr<T> context(const CoroFuturePtr<T>& ctx) {
+        return std::static_pointer_cast<Future<T>>(ctx);
+    }
+};
 
 #if (__cplusplus >= 201703L)
 
@@ -59,7 +81,17 @@ GenericFuture<T>::GenericFuture(ThreadFuturePtr<T> f) :
 }
 
 template <typename T>
-GenericFuture<T>::GenericFuture(CoroContextPtr<T> f, ICoroSyncPtr sync) :
+GenericFuture<T>::GenericFuture(CoroContextPtr<T> f) :
+    _context(f)
+{
+    if (!f) {
+        throw std::invalid_argument("Future pointer is null");
+    }
+}
+
+template <typename T>
+GenericFuture<T>::GenericFuture(CoroContextPtr<T> f,
+                                ICoroSyncPtr sync) :
     _context(f),
     _sync(sync)
 {
@@ -72,7 +104,17 @@ GenericFuture<T>::GenericFuture(CoroContextPtr<T> f, ICoroSyncPtr sync) :
 }
 
 template <typename T>
-GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f, ICoroSyncPtr sync) :
+GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f) :
+    _context(f)
+{
+    if (!f) {
+        throw std::invalid_argument("Future pointer is null");
+    }
+}
+
+template <typename T>
+GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f,
+                                ICoroSyncPtr sync) :
     _context(f),
     _sync(sync)
 {
@@ -83,12 +125,29 @@ GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f, ICoroSyncPtr sync) :
         throw std::invalid_argument("Sync context is null");
     }
 }
+
+template <typename T>
+GenericFuture<T>::GenericFuture(const GenericFuture& other) :
+    _context(other._context),
+    _sync(other._sync)
+{}
 
 template <typename T>
 GenericFuture<T>::GenericFuture(GenericFuture&& other) :
     _context(std::move(other._context)),
     _sync(std::move(other._sync))
 {}
+
+template <typename T>
+GenericFuture<T>& GenericFuture<T>::operator=(const GenericFuture& other)
+{
+    if (this == &other) {
+        return *this;
+    }
+    _context = other._context;
+    _sync = other._sync;
+    return *this;
+}
 
 template <typename T>
 GenericFuture<T>& GenericFuture<T>::operator=(GenericFuture&& other)
@@ -115,10 +174,38 @@ template <typename T>
 void GenericFuture<T>::wait() const
 {
     std::visit(Overloaded {
-        [](const ThreadContextPtr<T>& ctx) { assert(!local::context()); ctx->wait(); },
-        [](const ThreadFuturePtr<T>& ctx) { assert(!local::context()); ctx->wait(); },
-        [this](const CoroContextPtr<T>& ctx) { ctx->wait(_sync); },
-        [this](const CoroFuturePtr<T>& ctx) { ctx->wait(_sync); }
+        [](const ThreadContextPtr<T>& ctx) {
+            if (local::context()) {
+                cast::context<T>(ctx)->wait(local::context());
+            }
+            else {
+                ctx->wait();
+            }
+        },
+        [](const ThreadFuturePtr<T>& ctx) {
+            if (local::context()) {
+                cast::context<T>(ctx)->wait(local::context());
+            }
+            else {
+                ctx->wait();
+            }
+        },
+        [this](const CoroContextPtr<T>& ctx) {
+            if (local::context()) {
+                ctx->wait(_sync ? _sync : local::context());
+            }
+            else {
+                cast::context<T>(ctx)->wait();
+            }
+        },
+        [this](const CoroFuturePtr<T>& ctx) {
+            if (local::context()) {
+                ctx->wait(_sync ? _sync : local::context());
+            }
+            else {
+                cast::context<T>(ctx)->wait();
+            }
+        }
     }, _context);
 }
 
@@ -126,10 +213,38 @@ template <typename T>
 std::future_status GenericFuture<T>::waitFor(std::chrono::milliseconds timeMs) const
 {
     return std::visit(Overloaded {
-        [&](const ThreadContextPtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->waitFor(timeMs); },
-        [&](const ThreadFuturePtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->waitFor(timeMs); },
-        [&, this](const CoroContextPtr<T>& ctx)->decltype(auto) { return ctx->waitFor(_sync, timeMs); },
-        [&, this](const CoroFuturePtr<T>& ctx)->decltype(auto) { return ctx->waitFor(_sync, timeMs); }
+        [&](const ThreadContextPtr<T>& ctx)->decltype(auto) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->waitFor(local::context(), timeMs);
+            }
+            else {
+                return ctx->waitFor(timeMs);
+            }
+        },
+        [&](const ThreadFuturePtr<T>& ctx)->decltype(auto) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->waitFor(local::context(), timeMs);
+            }
+            else {
+                return ctx->waitFor(timeMs);
+            }
+        },
+        [&, this](const CoroContextPtr<T>& ctx)->decltype(auto) {
+            if (local::context()) {
+                return ctx->waitFor(_sync ? _sync : local::context(), timeMs);
+            }
+            else {
+                return cast::context<T>(ctx)->waitFor(timeMs);
+            }
+        },
+        [&, this](const CoroFuturePtr<T>& ctx)->decltype(auto) {
+            if (local::context()) {
+                return ctx->waitFor(_sync ? _sync : local::context(), timeMs);
+            }
+            else {
+                return cast::context<T>(ctx)->waitFor(timeMs);
+            }
+        }
     }, _context);
 }
 
@@ -138,10 +253,38 @@ template <typename V>
 NonBufferRetType<V> GenericFuture<T>::get()
 {
     return std::visit(Overloaded {
-        [](const ThreadContextPtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->get(); },
-        [](const ThreadFuturePtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->get(); },
-        [this](const CoroContextPtr<T>& ctx)->decltype(auto) { return ctx->get(_sync); },
-        [this](const CoroFuturePtr<T>& ctx)->decltype(auto) { return ctx->get(_sync); }
+        [](const ThreadContextPtr<T>& ctx) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->get(local::context());
+            }
+            else {
+                return ctx->get();
+            }
+        },
+        [](const ThreadFuturePtr<T>& ctx) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->get(local::context());
+            }
+            else {
+                return ctx->get();
+            }
+        },
+        [this](const CoroContextPtr<T>& ctx) {
+            if (local::context()) {
+                return ctx->get(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(ctx)->get();
+            }
+        },
+        [this](const CoroFuturePtr<T>& ctx) {
+            if (local::context()) {
+                return ctx->get(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(ctx)->get();
+            }
+        }
     }, _context);
 }
 
@@ -150,10 +293,38 @@ template <typename V>
 const NonBufferRetType<V>& GenericFuture<T>::getRef() const
 {
     return std::visit(Overloaded {
-        [](const ThreadContextPtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->getRef(); },
-        [](const ThreadFuturePtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->getRef(); },
-        [this](const CoroContextPtr<T>& ctx)->decltype(auto) { return ctx->getRef(_sync); },
-        [this](const CoroFuturePtr<T>& ctx)->decltype(auto) { return ctx->getRef(_sync); }
+        [](const ThreadContextPtr<T>& ctx) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->getRef(local::context());
+            }
+            else {
+                return ctx->get();
+            }
+        },
+        [](const ThreadFuturePtr<T>& ctx) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->getRef(local::context());
+            }
+            else {
+                return ctx->get();
+            }
+        },
+        [this](const CoroContextPtr<T>& ctx) {
+            if (local::context()) {
+                return ctx->getRef(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(ctx)->getRef();
+            }
+        },
+        [this](const CoroFuturePtr<T>& ctx) {
+            if (local::context()) {
+                return ctx->getRef(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(ctx)->getRef();
+            }
+        }
     }, _context);
 }
 
@@ -162,10 +333,38 @@ template <typename V>
 BufferRetType<V> GenericFuture<T>::pull(bool& isBufferClosed)
 {
     return std::visit(Overloaded {
-        [&](const ThreadContextPtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->pull(); },
-        [&](const ThreadFuturePtr<T>& ctx)->decltype(auto) { assert(!local::context()); return ctx->pull(); },
-        [&, this](const CoroContextPtr<T>& ctx)->decltype(auto) { return ctx->pull(_sync, isBufferClosed); },
-        [&, this](const CoroFuturePtr<T>& ctx)->decltype(auto) { return ctx->pull(_sync, isBufferClosed); }
+        [&](const ThreadContextPtr<T>& ctx) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->pull(local::context(), isBufferClosed);
+            }
+            else {
+                return ctx->pull(isBufferClosed);
+            }
+        },
+        [&](const ThreadFuturePtr<T>& ctx) {
+            if (local::context()) {
+                return cast::context<T>(ctx)->pull(local::context(), isBufferClosed);
+            }
+            else {
+                return ctx->pull(isBufferClosed);
+            }
+        },
+        [&, this](const CoroContextPtr<T>& ctx) {
+            if (local::context()) {
+                return ctx->pull(_sync ? _sync : local::context(), isBufferClosed);
+            }
+            else {
+                return cast::context<T>(ctx)->pull(isBufferClosed);
+            }
+        },
+        [&, this](const CoroFuturePtr<T>& ctx) {
+            if (local::context()) {
+                return ctx->pull(_sync ? _sync : local::context(), isBufferClosed);
+            }
+            else {
+                return cast::context<T>(ctx)->pull(isBufferClosed);
+            }
+        }
     }, _context);
 }
 
@@ -198,7 +397,18 @@ GenericFuture<T>::GenericFuture(ThreadFuturePtr<T> f) :
 }
 
 template <typename T>
-GenericFuture<T>::GenericFuture(CoroContextPtr<T> f, ICoroSyncPtr sync) :
+GenericFuture<T>::GenericFuture(CoroContextPtr<T> f) :
+    _type(Type::CoroContext),
+    _coroContext(f)
+{
+    if (!f) {
+        throw std::invalid_argument("Future pointer is null");
+    }
+}
+
+template <typename T>
+GenericFuture<T>::GenericFuture(CoroContextPtr<T> f,
+                                ICoroSyncPtr sync) :
     _type(Type::CoroContext),
     _coroContext(f),
     _sync(sync)
@@ -212,7 +422,18 @@ GenericFuture<T>::GenericFuture(CoroContextPtr<T> f, ICoroSyncPtr sync) :
 }
 
 template <typename T>
-GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f, ICoroSyncPtr sync) :
+GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f) :
+    _type(Type::CoroFuture),
+    _coroFuture(f)
+{
+    if (!f) {
+        throw std::invalid_argument("Future pointer is null");
+    }
+}
+
+template <typename T>
+GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f,
+                                ICoroSyncPtr sync) :
     _type(Type::CoroFuture),
     _coroFuture(f),
     _sync(sync)
@@ -226,11 +447,30 @@ GenericFuture<T>::GenericFuture(CoroFuturePtr<T> f, ICoroSyncPtr sync) :
 }
 
 template <typename T>
+GenericFuture<T>::GenericFuture(const GenericFuture& other) :
+    _type(other._type),
+    _threadContext(other._threadContext), //any union member is ok
+    _sync(other._sync)
+{}
+
+template <typename T>
 GenericFuture<T>::GenericFuture(GenericFuture&& other) :
     _type(other._type),
     _threadContext(std::move(other._threadContext)), //any union member is ok
     _sync(std::move(other._sync))
 {}
+
+template <typename T>
+GenericFuture<T>& GenericFuture<T>::operator=(const GenericFuture& other)
+{
+    if (this == &other) {
+        return *this;
+    }
+    _type = other._type;
+    _threadContext = other._threadContext; //any union member is ok
+    _sync = other._sync;
+    return *this;
+}
 
 template <typename T>
 GenericFuture<T>& GenericFuture<T>::operator=(GenericFuture&& other)
@@ -287,20 +527,36 @@ void GenericFuture<T>::wait() const
 {
     switch (_type) {
         case Type::ThreadContext:
-            //This will block the coroutine
-            assert(!local::context());
-            _threadContext->wait();
+            if (local::context()) {
+                cast::context<T>(_threadContext)->wait(local::context());
+            }
+            else {
+                _threadContext->wait();
+            }
             break;
         case Type::ThreadFuture:
-            //This will block the coroutine
-            assert(!local::context());
-            _threadFuture->wait();
+            if (local::context()) {
+                cast::context<T>(_threadFuture)->wait(local::context());
+            }
+            else {
+                _threadFuture->wait();
+            }
             break;
         case Type::CoroContext:
-            _coroContext->wait(_sync);
+            if (local::context()) {
+                _coroContext->wait(_sync ? _sync : local::context());
+            }
+            else {
+                cast::context<T>(_coroContext)->wait();
+            }
             break;
         case Type::CoroFuture:
-            _coroFuture->wait(_sync);
+            if (local::context()) {
+                _coroFuture->wait(_sync ? _sync : local::context());
+            }
+            else {
+                cast::context<T>(_coroFuture)->wait();
+            }
             break;
         default:
             throw FutureException(FutureState::NoState);
@@ -312,17 +568,33 @@ std::future_status GenericFuture<T>::waitFor(std::chrono::milliseconds timeMs) c
 {
     switch (_type) {
         case Type::ThreadContext:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadContext->waitFor(timeMs);
+            if (local::context()) {
+                return cast::context<T>(_threadContext)->waitFor(local::context(), timeMs);
+            }
+            else {
+                return _threadContext->waitFor(timeMs);
+            }
         case Type::ThreadFuture:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadFuture->waitFor(timeMs);
+            if (local::context()) {
+                return cast::context<T>(_threadFuture)->waitFor(local::context(), timeMs);
+            }
+            else {
+                return _threadFuture->waitFor(timeMs);
+            }
         case Type::CoroContext:
-            return _coroContext->waitFor(_sync, timeMs);
+            if (local::context()) {
+                return _coroContext->waitFor(_sync ? _sync : local::context(), timeMs);
+            }
+            else {
+                return cast::context<T>(_coroContext)->waitFor(timeMs);
+            }
         case Type::CoroFuture:
-            return _coroFuture->waitFor(_sync, timeMs);
+            if (local::context()) {
+                return _coroFuture->waitFor(_sync ? _sync : local::context(), timeMs);
+            }
+            else {
+                return cast::context<T>(_coroFuture)->waitFor(timeMs);
+            }
         default:
             throw FutureException(FutureState::NoState);
     }
@@ -334,17 +606,37 @@ NonBufferRetType<V> GenericFuture<T>::get()
 {
     switch (_type) {
         case Type::ThreadContext:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadContext->get();
+            if (local::context()) {
+                return cast::context<T>(_threadContext)->get(local::context());
+            }
+            else {
+                return _threadContext->get();
+            }
+            break;
         case Type::ThreadFuture:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadFuture->get();
+            if (local::context()) {
+                return cast::context<T>(_threadFuture)->get(local::context());
+            }
+            else {
+                return _threadFuture->get();
+            }
+            break;
         case Type::CoroContext:
-            return _coroContext->get(_sync);
+            if (local::context()) {
+                return _coroContext->get(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(_coroContext)->get();
+            }
+            break;
         case Type::CoroFuture:
-            return _coroFuture->get(_sync);
+            if (local::context()) {
+                return _coroFuture->get(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(_coroFuture)->get();
+            }
+            break;
         default:
             throw FutureException(FutureState::NoState);
     }
@@ -356,17 +648,37 @@ const NonBufferRetType<V>& GenericFuture<T>::getRef() const
 {
     switch (_type) {
         case Type::ThreadContext:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadContext->getRef();
+            if (local::context()) {
+                return cast::context<T>(_threadContext)->getRef(local::context());
+            }
+            else {
+                return _threadContext->getRef();
+            }
+            break;
         case Type::ThreadFuture:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadFuture->getRef();
+            if (local::context()) {
+                return cast::context<T>(_threadFuture)->getRef(local::context());
+            }
+            else {
+                return _threadFuture->getRef();
+            }
+            break;
         case Type::CoroContext:
-            return _coroContext->getRef(_sync);
+            if (local::context()) {
+                return _coroContext->getRef(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(_coroContext)->getRef();
+            }
+            break;
         case Type::CoroFuture:
-            return _coroFuture->getRef(_sync);
+            if (local::context()) {
+                return _coroFuture->getRef(_sync ? _sync : local::context());
+            }
+            else {
+                return cast::context<T>(_coroFuture)->getRef();
+            }
+            break;
         default:
             throw FutureException(FutureState::NoState);
     }
@@ -378,17 +690,33 @@ BufferRetType<V> GenericFuture<T>::pull(bool& isBufferClosed)
 {
     switch (_type) {
         case Type::ThreadContext:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadContext->pull(isBufferClosed);
+            if (local::context()) {
+                return cast::context<T>(_threadContext)->pull(local::context(), isBufferClosed);
+            }
+            else {
+                return _threadContext->pull(isBufferClosed);
+            }
         case Type::ThreadFuture:
-            //This will block the coroutine
-            assert(!local::context());
-            return _threadFuture->pull(isBufferClosed);
+            if (local::context()) {
+                return cast::context<T>(_threadFuture)->pull(local::context(), isBufferClosed);
+            }
+            else {
+                return _threadFuture->pull(isBufferClosed);
+            }
         case Type::CoroContext:
-            return _coroContext->pull(_sync, isBufferClosed);
+            if (local::context()) {
+                return _coroContext->pull(_sync ? _sync : local::context(), isBufferClosed);
+            }
+            else {
+                return cast::context<T>(_coroContext)->pull(isBufferClosed);
+            }
         case Type::CoroFuture:
-            return _coroFuture->pull(_sync, isBufferClosed);
+            if (local::context()) {
+                return _coroFuture->pull(_sync ? _sync : local::context(), isBufferClosed);
+            }
+            else {
+                return cast::context<T>(_coroFuture)->pull(isBufferClosed);
+            }
         default:
             throw FutureException(FutureState::NoState);
     }

--- a/quantum/util/quantum_generic_future.h
+++ b/quantum/util/quantum_generic_future.h
@@ -41,9 +41,13 @@ public:
     GenericFuture();
     GenericFuture(ThreadContextPtr<T> f);
     GenericFuture(ThreadFuturePtr<T> f);
+    GenericFuture(CoroContextPtr<T> f); //uses local context
     GenericFuture(CoroContextPtr<T> f, ICoroSyncPtr sync);
+    GenericFuture(CoroFuturePtr<T> f); //uses local context
     GenericFuture(CoroFuturePtr<T> f, ICoroSyncPtr sync);
+    GenericFuture(const GenericFuture& other);
     GenericFuture(GenericFuture&& other);
+    GenericFuture& operator=(const GenericFuture& other);
     GenericFuture& operator=(GenericFuture&& other);
     ~GenericFuture();
     

--- a/tests/quantum_generic_future_tests.cpp
+++ b/tests/quantum_generic_future_tests.cpp
@@ -1,0 +1,98 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#include <quantum/quantum_dispatcher.h>
+#include <quantum/util/quantum_generic_future.h>
+#include <quantum_fixture.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace Bloomberg::quantum;
+using ms = std::chrono::milliseconds;
+
+TEST(GenericFuture, MakeFutureInCoroutineAndMainThread)
+{
+    Dispatcher& dispatcher = DispatcherSingleton::instance({false, false});
+    GenericFuture<int> threadFuture = dispatcher.post([](VoidContextPtr ctx)->int {
+        //post an IO task and get future from there
+        GenericFuture<int> coroFuture(ctx->postAsyncIo([]()->int {
+            return 33;
+        }), ctx);
+        return coroFuture.get(); //forward the promise to main thread
+    });
+    EXPECT_EQ(33, threadFuture.get()); //block until value is available
+}
+
+TEST(GenericFuture, WaitForCoroutineFutureInIoTask)
+{
+    Dispatcher& dispatcher = DispatcherSingleton::instance({false, false});
+    GenericFuture<int> threadFuture = dispatcher.post([](VoidContextPtr ctx)->int {
+        //post an IO task and get future from there
+        volatile int i = 0;
+        GenericFuture<int> coroFuture0(ctx->postAsyncIo([&i]()->int {
+            while (i==0) {
+                std::this_thread::sleep_for(ms(10));
+            }
+            return 33;
+        }), ctx);
+        
+        //start another IO task and wait in the previous future
+        GenericFuture<int> coroFuture1(ctx->postAsyncIo([&i, &coroFuture0]()->int {
+            //wait on this future
+            i = 1;
+            return coroFuture0.get() + 10; //wait on the coroutine future
+        }), ctx);
+        
+        return coroFuture1.get(); //return value to main thread
+    });
+    EXPECT_EQ(43, threadFuture.get()); //block until value is available
+}
+
+TEST(GenericFuture, WaitForIoFutureInCoroutine)
+{
+    Dispatcher& dispatcher = DispatcherSingleton::instance({false, false});
+    volatile int i = 0;
+    GenericFuture<int> ioFuture = dispatcher.postAsyncIo([&i]()->int {
+        while (i==0) {
+            std::this_thread::sleep_for(ms(10));
+        }
+        return 33;
+    });
+    
+    GenericFuture<int> threadFuture = dispatcher.post([&i, &ioFuture](VoidContextPtr)->int {
+        i = 1;
+        return ioFuture.get() + 10;
+    });
+    
+    EXPECT_EQ(43, threadFuture.get()); //block until value is available
+}
+
+TEST(GenericFuture, TestCopyable)
+{
+    Dispatcher& dispatcher = DispatcherSingleton::instance({false, false});
+    std::vector<GenericFuture<int>> v;
+    
+    //create one future
+    v.push_back(dispatcher.post([](VoidContextPtr)->int{ return 33; }));
+    
+    //copy it
+    v.push_back(v.front());
+    
+    //read the value from the first future
+    EXPECT_EQ(33, v.front().get());
+    
+    //read from the second future and we should throw
+    EXPECT_THROW(v.back().get(), FutureAlreadyRetrievedException);
+}

--- a/tests/quantum_tests.cpp
+++ b/tests/quantum_tests.cpp
@@ -775,19 +775,6 @@ TEST_P(PromiseTest, GetFutureFromIoTask2)
     EXPECT_EQ(33, ctx->get()); //block until value is available
 }
 
-TEST_P(PromiseTest, GetGenericFutureFromIoTask)
-{
-    Dispatcher& dispatcher = getDispatcher();
-    GenericFuture<int> genFuture = dispatcher.post([](CoroContext<int>::Ptr ctx)->int{
-        //post an IO task and get future from there
-        GenericFuture<double> genFuture(ctx->postAsyncIo([](ThreadPromise<double>::Ptr promise)->int{
-            return promise->set(33.22);
-        }), ctx);
-        return ctx->set((int)genFuture.get()); //forward the promise
-    });
-    EXPECT_EQ(33, genFuture.get()); //block until value is available
-}
-
 TEST_P(PromiseTest, GetFutureFromExternalSource)
 {
     Dispatcher& dispatcher = getDispatcher();


### PR DESCRIPTION
**Describe your changes**

Allow generic futures to be accessed from coroutines and threads interchangeably. This prevents unwanted blocking of the coroutine thread.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>
