### PR TITLE
Fix validity check on generic futures when they are default constructed

### DIFF
--- a/quantum/util/impl/quantum_generic_future_impl.h
+++ b/quantum/util/impl/quantum_generic_future_impl.h
@@ -178,7 +178,7 @@ GenericFuture<T>::~GenericFuture()
 template <typename T>
 bool GenericFuture<T>::valid() const
 {
-    return std::visit([](const auto& ctx)->bool { return ctx->valid(); }, _context);
+    return std::visit([](const auto& ctx)->bool { return ctx ? ctx->valid() : false; }, _context);
 }
 
 template <typename T>

--- a/tests/quantum_generic_future_tests.cpp
+++ b/tests/quantum_generic_future_tests.cpp
@@ -76,6 +76,8 @@ TEST(GenericFuture, WaitForIoFutureInCoroutine)
         return ioFuture.get() + 10;
     });
     
+    EXPECT_TRUE(threadFuture.valid());
+    
     EXPECT_EQ(43, threadFuture.get()); //block until value is available
 }
 
@@ -98,4 +100,10 @@ TEST(GenericFuture, TestCopyable)
     
     //read from the second future and we should throw
     EXPECT_THROW(v.back().get(), FutureAlreadyRetrievedException);
+}
+
+TEST(GenericFuture, Invalid)
+{
+    GenericFuture<int> future; //default constructed
+    EXPECT_FALSE(future.valid());
 }


### PR DESCRIPTION
**Describe your changes**
Fix validity check on generic futures when they are default constructed

Signed-off-by: Alexander Damian <adamian@bloomberg.net>

