### PR TITLE
Provide local::context() to Mutex::Guard

### DIFF
--- a/quantum/util/impl/quantum_sequencer_experimental_impl.h
+++ b/quantum/util/impl/quantum_sequencer_experimental_impl.h
@@ -20,6 +20,7 @@
 //##############################################################################################
 
 #include <quantum/util/quantum_drain_guard.h>
+#include <quantum/quantum_local.h>
 #include <quantum/quantum_promise.h>
 #include <quantum/quantum_traits.h>
 #include <quantum/impl/quantum_stl_impl.h>
@@ -281,7 +282,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueSingle(
         queueId,
         isHighPriority);
 
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
 
     _taskStats->incrementPostedTaskCount();
     _taskStats->incrementPendingTaskCount();
@@ -344,7 +345,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueMultiple(
         queueId,
         isHighPriority);
 
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
 
     _taskStats->incrementPostedTaskCount();
     _taskStats->incrementPendingTaskCount();
@@ -410,7 +411,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::enqueueAllImpl(
         queueId,
         isHighPriority);
 
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
 
     _taskStats->incrementPostedTaskCount();
     _taskStats->incrementPendingTaskCount();
@@ -433,7 +434,7 @@ template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 size_t
 Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::trimSequenceKeys()
 {
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
     for(typename PendingTaskQueueMap::iterator it = _pendingTaskQueueMap.begin(); it != _pendingTaskQueueMap.end(); )
     {
         if (it->second._tasks.empty())
@@ -448,7 +449,7 @@ template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 SequenceKeyStatistics
 Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getStatistics(const SequenceKey& sequenceKey)
 {
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
     typename PendingTaskQueueMap::const_iterator it = _pendingTaskQueueMap.find(sequenceKey);
     if (it == _pendingTaskQueueMap.end())
         return SequenceKeyStatistics();
@@ -459,7 +460,7 @@ template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 SequenceKeyStatistics
 Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getStatistics()
 {
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
     return *_universalTaskQueue._stats;
 }
 
@@ -474,7 +475,7 @@ template <class SequenceKey, class Hash, class KeyEqual, class Allocator>
 size_t
 Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::getSequenceKeyCount()
 {
-    Mutex::Guard lock(_mutex);
+    Mutex::Guard lock(local::context(), _mutex);
     return _pendingTaskQueueMap.size();
 }
 

--- a/tests/quantum_sequencer_experimental_tests.cpp
+++ b/tests/quantum_sequencer_experimental_tests.cpp
@@ -670,4 +670,19 @@ TEST_P(SequencerExperimentalTest, PerformanceTest)
         0);
 }
 
+TEST_P(SequencerExperimentalTest, CoroSafety)
+{
+    // This test demonstrates that it is safe to call the experimental::Sequencer from within a
+    // coroutine
+
+    SequencerExperimentalTestData::TaskSequencer sequencer{ getDispatcher() };
+
+    getDispatcher().post([&sequencer](VoidContextPtr ctx) -> int {
+        sequencer.enqueue(0, [](VoidContextPtr ctx) -> int { return 0; });
+        return 0;
+    });
+
+    getDispatcher().drain();
+}
+
 #endif // BLOOMBERG_QUANTUM_SEQUENCER_LITE_SUPPORT


### PR DESCRIPTION
Signed-off-by: Adam M. Rosenzweig <arosenzweig3@bloomberg.net>

*Issue number of the reported bug or feature request: N/A*

**Describe your changes**
@demin80 's new `experimental::Sequencer` cannot be called safely from inside a coroutine. Many of our internal use-cases in fact call into the `Sequencer` from within coroutines, but because the `Mutex::Guard` constructors that do not take a `ICoroSync::Ptr` `assert(!local::context())`, the task crashes. 
The change is to use the constructor which does take an `ICoroSync::Ptr` and populate it from `local::context()`; this is safe whether the `Sequencer` is invoked from within a coroutine or not.

**Testing performed**
After identifying the problem separately, I added a unit test (SequencerExperimentalTest, CoroSafety) and confirmed that this caused an assertion and crash of the test executable. Then I amended the `Mutex::Guard` objects to take in `local::context()` and re-ran the tests, which now all passed without a crash.

