### PR TITLE
Rename DEPRECATED macro

### DIFF
--- a/quantum/quantum_macros.h
+++ b/quantum/quantum_macros.h
@@ -16,14 +16,6 @@
 #ifndef BLOOMBERG_QUANTUM_MACROS_H
 #define BLOOMBERG_QUANTUM_MACROS_H
 
-#if defined(__GNUC__) || defined(__clang__)
-    #define DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-    #define DEPRECATED __declspec(deprecated)
-#else
-    #define DEPRECATED
-#endif
-
 #define QUANTUM_BACKOFF_LINEAR 0
 #define QUANTUM_BACKOFF_EXPONENTIAL 1
 #define QUANTUM_BACKOFF_EQUALSTEP 2

--- a/quantum/quantum_macros.h
+++ b/quantum/quantum_macros.h
@@ -16,6 +16,14 @@
 #ifndef BLOOMBERG_QUANTUM_MACROS_H
 #define BLOOMBERG_QUANTUM_MACROS_H
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define QUANTUM_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+    #define QUANTUM_DEPRECATED __declspec(deprecated)
+#else
+    #define QUANTUM_DEPRECATED
+#endif
+
 #define QUANTUM_BACKOFF_LINEAR 0
 #define QUANTUM_BACKOFF_EXPONENTIAL 1
 #define QUANTUM_BACKOFF_EQUALSTEP 2


### PR DESCRIPTION
Signed-off-by: Adam M. Rosenzweig <arosenzweig3@bloomberg.net>

**Describe your changes**
Remove the DEPRECATED macro, which was causing conflicts in downstream libraries and/or applications which linked in `quantum` and also other code which referenced `DEPRECATED` (for other purposes).

As quantum is not using these macros at all, I have chosen to remove them rather than rename them.

**Testing performed**
Verified that `quantum` builds, all tests still pass, and that all of our internal tasks & libraries that depend on `quantum` build successfully with the change.
