### PR TITLE
Removed used of deprecated forced_unwind

### DIFF
--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <list>
 #include <utility>
+#include <atomic>
 
 namespace Bloomberg {
 namespace quantum {

--- a/quantum/quantum_traits.h
+++ b/quantum/quantum_traits.h
@@ -48,7 +48,6 @@ struct Traits
     using BoostCoro = boost::coroutines2::coroutine<int&>;
     using Yield     = typename BoostCoro::pull_type;
     using Coroutine = typename BoostCoro::push_type;
-    //NOTE: 'boost::coroutines2::detail::forced_unwind' is deprecated
     using CoroutineStackUnwind = boost::context::detail::forced_unwind;
     
     template <class IT>

--- a/quantum/util/impl/quantum_sequencer_experimental_impl.h
+++ b/quantum/util/impl/quantum_sequencer_experimental_impl.h
@@ -24,6 +24,7 @@
 #include <quantum/quantum_promise.h>
 #include <quantum/quantum_traits.h>
 #include <quantum/impl/quantum_stl_impl.h>
+#include <boost/context/detail/exception.hpp>
 #include <stdexcept>
 #include <functional>
 
@@ -187,7 +188,7 @@ Sequencer<SequenceKey, Hash, KeyEqual, Allocator>::executePending(
     {
         rc = task->_func(ctx);
     }
-    catch(const boost::coroutines2::detail::forced_unwind&)
+    catch(const boost::context::detail::forced_unwind&)
     {
         // quantum context switch
         throw;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #157*

**Describe your changes**
It replaces the (removed) used of boost::coroutine2::detail::forced_unwind in a catch with boost::context

**Testing performed**
Just a basic compilation.

**Additional context**
Details described in issue #157 
