### PR TITLE
Only use cpu_set_t on Linux

### DIFF
--- a/quantum/impl/quantum_task_queue_impl.h
+++ b/quantum/impl/quantum_task_queue_impl.h
@@ -94,7 +94,7 @@ void TaskQueue::pinToCore(int coreId)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
     SetThreadAffinityMask(_thread->native_handle(), 1 << coreId);
-#else
+#elif defined(__linux__)
     int cpuSetSize = sizeof(cpu_set_t);
     if (coreId >= 0 && (coreId <= cpuSetSize*8))
     {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #*

**Describe your changes**

Makes `TaskQueue::pinToCore` a no-op on platforms that don't support `cpu_set_t` (i.e. non-Linux)

**Testing performed**

Compiled quantum on macOS.

**Additional context**

In the future, `TaskQueue::pinToCore` should be implemented on other platforms to improve performance.