### PR TITLE
Add missing atomic header to quantum_task.h

### DIFF
--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <list>
 #include <utility>
+#include <atomic>
 
 namespace Bloomberg {
 namespace quantum {


### PR DESCRIPTION
Signed-off-by: Albert Dang <adang2@bloomberg.net>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

atomic header missing in quantum_task.h which caused build failure with c++ 20.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
