### PR TITLE
Update memory_model for store()

### DIFF
--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -128,12 +128,12 @@ private:
         {
             if (_isLocked)
             {
-                _suspendedState.store((int)State::Suspended, std::memory_order_acq_rel);
+                _suspendedState.store((int)State::Suspended, std::memory_order_release);
             }
         }
         void set(int newState)
         {
-            _suspendedState.store(newState, std::memory_order_acq_rel);
+            _suspendedState.store(newState, std::memory_order_release);
             _isLocked = false;
         }
 


### PR DESCRIPTION
**Describe your changes**
gcc-12 now reports a warning when `std::memory_order_acq_rel` is used on a `store()` operation. Correct this to `std::memory_order_release`

**Testing performed**
Testing in this case limited to existing CI.

**Additional context**
None.
