### PR TITLE
Update store() memory model

### DIFF
--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -128,12 +128,12 @@ private:
         {
             if (_isLocked)
             {
-                _suspendedState.store((int)State::Suspended, std::memory_order_acq_rel);
+                _suspendedState.store((int)State::Suspended, std::memory_order_release);
             }
         }
         void set(int newState)
         {
-            _suspendedState.store(newState, std::memory_order_acq_rel);
+            _suspendedState.store(newState, std::memory_order_release);
             _isLocked = false;
         }
 


### PR DESCRIPTION
**Describe your changes**

In `gcc-12`, new warnings trigger when an invalid memory model is provided to atomic functions. `std::memory_order_acq_rel` is not valid for `store()`. Change this to `std::memory_order_release`.

**Testing performed**
Testing limited to existing CI.

**Additional context**
None.
