### PR TITLE
Use std::memory_order_seq_cst for store()

### DIFF
--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -128,12 +128,12 @@ private:
         {
             if (_isLocked)
             {
-                _suspendedState.store((int)State::Suspended, std::memory_order_acq_rel);
+                _suspendedState.store((int)State::Suspended, std::memory_order_release);
             }
         }
         void set(int newState)
         {
-            _suspendedState.store(newState, std::memory_order_acq_rel);
+            _suspendedState.store(newState, std::memory_order_release);
             _isLocked = false;
         }
 

--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -128,12 +128,12 @@ private:
         {
             if (_isLocked)
             {
-                _suspendedState.store((int)State::Suspended, std::memory_order_release);
+                _suspendedState.store((int)State::Suspended, std::memory_order_seq_cst);
             }
         }
         void set(int newState)
         {
-            _suspendedState.store(newState, std::memory_order_release);
+            _suspendedState.store(newState, std::memory_order_seq_cst);
             _isLocked = false;
         }
 


### PR DESCRIPTION
**Describe your changes**
In `gcc-12`, a new warning triggers when an inappropriate `std::memory_order` is passed to an atomic function. Corrected `std::memory_order_acq_rel` to `std::memory_order_release` for the `store()` calls.

**Testing performed**
Testing limited to running CI.

**Additional context**
No additional context.
